### PR TITLE
KAN- 6 Add tooltips to the Create-Update company

### DIFF
--- a/src/pages/company/components/RegisterCompanyForm.tsx
+++ b/src/pages/company/components/RegisterCompanyForm.tsx
@@ -81,7 +81,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<FaRegBuilding />}
                 placeholder={Strings.companyName}
               />
-              <Tooltip title="Legal name of the company">
+              <Tooltip title={Strings.companyNameTooltip}>
                 <QuestionCircleOutlined className="ml-1.5 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -109,7 +109,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                   ).value.toUpperCase())
                 }
               />
-              <Tooltip title="The RFC (Federal Taxpayer Registry) must consist of 12 characters for individuals or 13 characters for legal entities. It includes letters and numbers: the first letters correspond to the name or business name, followed by the date of incorporation or birth, and a verification digit. Ensure it matches the official format.">
+              <Tooltip title={Strings.rfcTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -128,7 +128,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
               addonBefore={<SlCompass />}
               placeholder={Strings.companyAddress}
             />
-            <Tooltip title="Complete address of the company, including street and city.">
+            <Tooltip title={Strings.addressTooltip}>
               <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
             </Tooltip>
           </div>
@@ -149,7 +149,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<IoIosContact />}
                 placeholder={Strings.contact}
               />
-              <Tooltip title="Name of the primary contact person.">
+              <Tooltip title={Strings.contactNameTooltip}>
                 <QuestionCircleOutlined className="ml-1.5 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -169,7 +169,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<BsDiagram3 />}
                 placeholder={Strings.position}
               />
-              <Tooltip title="Job position of the contact person.">
+              <Tooltip title={Strings.positionTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -187,7 +187,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<MdOutlineLocalPhone />}
                 placeholder={Strings.phone}
               />
-              <Tooltip title="Company's landline number.">
+              <Tooltip title={Strings.phoneTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -200,7 +200,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<TiPlusOutline />}
                 placeholder={Strings.extension}
               />
-              <Tooltip title="Extension for the phone number (if applicable).">
+              <Tooltip title={Strings.extensionTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -216,7 +216,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
                 addonBefore={<HiDevicePhoneMobile />}
                 placeholder={Strings.cellular}
               />
-              <Tooltip title="Primary mobile phone number.">
+              <Tooltip title={Strings.cellularTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -237,7 +237,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
               addonBefore={<MailOutlined />}
               placeholder={Strings.email}
             />
-            <Tooltip title="Official company email address.">
+            <Tooltip title={Strings.emailTooltip}>
               <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
             </Tooltip>
           </div>
@@ -249,7 +249,7 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
           rules={[{ required: true, message: Strings.requiredLogo }]}
           className="mt-4"
         >
-          <Tooltip title="Upload the company logo in image format.">
+          <Tooltip title={Strings.logoTooltip}>
             <QuestionCircleOutlined className="mb-2 text-blue-500 text-xs" />
           </Tooltip>
           <div className="flex items-center">

--- a/src/pages/company/components/RegisterCompanyForm.tsx
+++ b/src/pages/company/components/RegisterCompanyForm.tsx
@@ -8,8 +8,9 @@ import {
   Upload,
   UploadFile,
   UploadProps,
+  Tooltip,
 } from "antd";
-import { MailOutlined } from "@ant-design/icons";
+import { MailOutlined, QuestionCircleOutlined } from "@ant-design/icons";
 import { FaRegBuilding } from "react-icons/fa";
 import { MdOutlineLocalPhone, MdOutlineQrCodeScanner } from "react-icons/md";
 import { SlCompass } from "react-icons/sl";
@@ -54,9 +55,9 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
   };
 
   const uploadButton = (
-    <button style={{ border: 0, background: "none" }} type="button">
+    <button className="border-0 bg-none" type="button">
       <PlusOutlined />
-      <div style={{ marginTop: 8 }}>Upload</div>
+      <div className="mt-2">Upload</div>
     </button>
   );
 
@@ -71,14 +72,19 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
               { required: true, message: Strings.requiredCompanyName },
               { max: 100 },
             ]}
-            className="flex-1 mr-1"
+            className="flex-1 mr-3"
           >
-            <Input
-              size="large"
-              maxLength={100}
-              addonBefore={<FaRegBuilding />}
-              placeholder={Strings.companyName}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<FaRegBuilding />}
+                placeholder={Strings.companyName}
+              />
+              <Tooltip title="Legal name of the company">
+                <QuestionCircleOutlined className="ml-1.5 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="rfc"
@@ -89,19 +95,24 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
               { min: 12 },
             ]}
           >
-            <Input
-              size="large"
-              showCount
-              maxLength={13}
-              minLength={12}
-              addonBefore={<MdOutlineQrCodeScanner />}
-              placeholder={Strings.rfc}
-              onInput={(e) =>
-                ((e.target as HTMLInputElement).value = (
-                  e.target as HTMLInputElement
-                ).value.toUpperCase())
-              }
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                showCount
+                maxLength={13}
+                minLength={12}
+                addonBefore={<MdOutlineQrCodeScanner />}
+                placeholder={Strings.rfc}
+                onInput={(e) =>
+                  ((e.target as HTMLInputElement).value = (
+                    e.target as HTMLInputElement
+                  ).value.toUpperCase())
+                }
+              />
+              <Tooltip title="The RFC (Federal Taxpayer Registry) must consist of 12 characters for individuals or 13 characters for legal entities. It includes letters and numbers: the first letters correspond to the name or business name, followed by the date of incorporation or birth, and a verification digit. Ensure it matches the official format.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <Form.Item
@@ -111,11 +122,16 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
             { max: 200 },
           ]}
         >
-          <Input
-            size="large"
-            addonBefore={<SlCompass />}
-            placeholder={Strings.companyAddress}
-          />
+          <div className="flex items-center">
+            <Input
+              size="large"
+              addonBefore={<SlCompass />}
+              placeholder={Strings.companyAddress}
+            />
+            <Tooltip title="Complete address of the company, including street and city.">
+              <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+            </Tooltip>
+          </div>
         </Form.Item>
         <div className="flex flex-row flex-wrap">
           <Form.Item
@@ -124,14 +140,19 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
               { required: true, message: Strings.requiredContacName },
               { max: 100 },
             ]}
-            className="flex-1 mr-1"
+            className="flex-1 mr-3"
           >
-            <Input
-              size="large"
-              maxLength={100}
-              addonBefore={<IoIosContact />}
-              placeholder={Strings.contact}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<IoIosContact />}
+                placeholder={Strings.contact}
+              />
+              <Tooltip title="Name of the primary contact person.">
+                <QuestionCircleOutlined className="ml-1.5 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="position"
@@ -141,12 +162,17 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
             ]}
             className="flex-1"
           >
-            <Input
-              size="large"
-              maxLength={100}
-              addonBefore={<BsDiagram3 />}
-              placeholder={Strings.position}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<BsDiagram3 />}
+                placeholder={Strings.position}
+              />
+              <Tooltip title="Job position of the contact person.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <div className="flex justify-between flex-row flex-wrap">
@@ -154,31 +180,46 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
             name="phone"
             rules={[{ required: true, message: Strings.requiredPhone }]}
           >
-            <InputNumber
-              size="large"
-              maxLength={10}
-              addonBefore={<MdOutlineLocalPhone />}
-              placeholder={Strings.phone}
-            />
+            <div className="flex items-center">
+              <InputNumber
+                size="large"
+                maxLength={10}
+                addonBefore={<MdOutlineLocalPhone />}
+                placeholder={Strings.phone}
+              />
+              <Tooltip title="Company's landline number.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item name="extension">
-            <InputNumber
-              size="large"
-              maxLength={5}
-              addonBefore={<TiPlusOutline />}
-              placeholder={Strings.extension}
-            />
+            <div className="flex items-center">
+              <InputNumber
+                size="large"
+                maxLength={5}
+                addonBefore={<TiPlusOutline />}
+                placeholder={Strings.extension}
+              />
+              <Tooltip title="Extension for the phone number (if applicable).">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="cellular"
             rules={[{ required: true, message: Strings.requiredCellular }]}
           >
-            <InputNumber
-              size="large"
-              maxLength={13}
-              addonBefore={<HiDevicePhoneMobile />}
-              placeholder={Strings.cellular}
-            />
+            <div className="flex items-center">
+              <InputNumber
+                size="large"
+                maxLength={13}
+                addonBefore={<HiDevicePhoneMobile />}
+                placeholder={Strings.cellular}
+              />
+              <Tooltip title="Primary mobile phone number.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <Form.Item
@@ -189,29 +230,43 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
             { max: 60 },
           ]}
         >
-          <Input
-            size="large"
-            maxLength={60}
-            addonBefore={<MailOutlined />}
-            placeholder={Strings.email}
-          />
+          <div className="flex items-center">
+            <Input
+              size="large"
+              maxLength={60}
+              addonBefore={<MailOutlined />}
+              placeholder={Strings.email}
+            />
+            <Tooltip title="Official company email address.">
+              <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+            </Tooltip>
+          </div>
         </Form.Item>
         <Form.Item
           name="logo"
-          label={Strings.logo}
+          label={<div className="flex items-center">{Strings.logo}</div>}
           getValueFromEvent={(event) => event?.fileList}
           rules={[{ required: true, message: Strings.requiredLogo }]}
+          className="mt-4"
         >
-          <Upload
-            maxCount={1}
-            accept="image/*"
-            listType="picture-card"
-            onPreview={handleOnPreview}
-            onChange={handleChange}
-            fileList={fileList}
-          >
-            {uploadButton}
-          </Upload>
+          <Tooltip title="Upload the company logo in image format.">
+            <QuestionCircleOutlined className="mb-2 text-blue-500 text-xs" />
+          </Tooltip>
+          <div className="flex items-center">
+            <Upload
+              maxCount={1}
+              accept="image/*"
+              listType="picture-card"
+              onPreview={handleOnPreview}
+              onChange={handleChange}
+              fileList={fileList}
+            >
+              <button className="border-0 bg-none" type="button">
+                <PlusOutlined />
+                <div className="mt-2">Upload</div>
+              </button>
+            </Upload>
+          </div>
         </Form.Item>
         <Form.Item>
           {previewImage && (
@@ -230,5 +285,4 @@ const RegisterCompanyForm = ({ form }: FormProps) => {
     </Form>
   );
 };
-
 export default RegisterCompanyForm;

--- a/src/pages/company/components/UpdateCompanyForm.tsx
+++ b/src/pages/company/components/UpdateCompanyForm.tsx
@@ -10,15 +10,20 @@ import {
   Upload,
   UploadFile,
   UploadProps,
+  Tooltip,
 } from "antd";
 import Strings from "../../../utils/localizations/Strings";
+import {
+  MailOutlined,
+  QuestionCircleOutlined,
+  PlusOutlined,
+} from "@ant-design/icons";
 import { FaRegBuilding } from "react-icons/fa";
 import { MdOutlineLocalPhone, MdOutlineQrCodeScanner } from "react-icons/md";
 import { IoIosContact } from "react-icons/io";
 import { BsDiagram3 } from "react-icons/bs";
 import { TiPlusOutline } from "react-icons/ti";
 import { HiDevicePhoneMobile } from "react-icons/hi2";
-import { PlusOutlined, MailOutlined } from "@ant-design/icons";
 import { SlCompass } from "react-icons/sl";
 import { Company } from "../../../data/company/company";
 import { selectCurrentRowData } from "../../../core/genericReducer";
@@ -94,7 +99,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               { required: true, message: Strings.requiredCompanyName },
               { max: 100 },
             ]}
-            className="flex-1 mr-1"
+            className="flex-1 mr-2"
           >
             <Input
               size="large"
@@ -103,6 +108,9 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.companyName}
             />
           </Form.Item>
+          <Tooltip title="Legal name of the company">
+            <QuestionCircleOutlined className="h-9 mr-2 text-blue-500 text-sm" />
+          </Tooltip>
           <Form.Item
             name="rfc"
             validateFirst
@@ -126,20 +134,30 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               }
             />
           </Form.Item>
+          <Tooltip title="The RFC (Federal Taxpayer Registry) must consist of 12 characters for individuals or 13 characters for legal entities. It includes letters and numbers: the first letters correspond to the name or business name, followed by the date of incorporation or birth, and a verification digit. Ensure it matches the official format.">
+            <QuestionCircleOutlined className="ml-2 h-9 text-blue-500 text-sm" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="address"
-          rules={[
-            { required: true, message: Strings.requiredAddress },
-            { max: 200 },
-          ]}
-        >
-          <Input
-            size="large"
-            addonBefore={<SlCompass />}
-            placeholder={Strings.companyAddress}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="address"
+            rules={[
+              { required: true, message: Strings.requiredAddress },
+              { max: 200 },
+            ]}
+            className="flex-grow"
+          >
+            <Input
+              size="large"
+              addonBefore={<SlCompass />}
+              placeholder={Strings.companyAddress}
+            />
+          </Form.Item>
+          <Tooltip title="Complete address of the company, including street and city.">
+            <QuestionCircleOutlined className="mb-6 ml-2 text-blue-500 text-sm" />
+          </Tooltip>
+        </div>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="contact"
@@ -156,6 +174,9 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.contact}
             />
           </Form.Item>
+          <Tooltip title="Name of the primary contact person.">
+            <QuestionCircleOutlined className="h-9 ml-1 mr-1.5 text-blue-500 text-sm" />
+          </Tooltip>
           <Form.Item
             name="position"
             rules={[
@@ -171,8 +192,11 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.position}
             />
           </Form.Item>
+          <Tooltip title="Job position of the contact person.">
+            <QuestionCircleOutlined className="h-9 ml-1.5  text-blue-500 text-sm" />
+          </Tooltip>
         </div>
-        <div className="flex justify-between flex-row flex-wrap">
+        <div className="flex justify-between flex-row ">
           <Form.Item
             name="phone"
             rules={[{ required: true, message: Strings.requiredPhone }]}
@@ -184,6 +208,9 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.phone}
             />
           </Form.Item>
+          <Tooltip title="Company's landline number.">
+            <QuestionCircleOutlined className="h-9 ml-1.5 mr-1.5  text-blue-500 text-sm" />
+          </Tooltip>
           <Form.Item name="extension">
             <InputNumber
               size="large"
@@ -192,6 +219,9 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.extension}
             />
           </Form.Item>
+          <Tooltip title="Extension for the phone number (if applicable).">
+            <QuestionCircleOutlined className="h-9 ml-1.5 mr-1.5  text-blue-500 text-sm" />
+          </Tooltip>
           <Form.Item
             name="cellular"
             rules={[{ required: true, message: Strings.requiredCellular }]}
@@ -203,42 +233,56 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.cellular}
             />
           </Form.Item>
+          <Tooltip title="Primary mobile phone number.">
+            <QuestionCircleOutlined className="h-9 ml-1.5  text-blue-500 text-sm" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="email"
-          rules={[
-            { required: true, message: Strings.requiredEmail },
-            { type: "email", message: Strings.requiredValidEmailAddress },
-            { max: 60 },
-          ]}
-        >
-          <Input
-            size="large"
-            maxLength={60}
-            addonBefore={<MailOutlined />}
-            placeholder={Strings.email}
-          />
-        </Form.Item>
-        <Form.Item name="logoURL" className="hidden">
-          <Input />
-        </Form.Item>
-        <Form.Item
-          name="logo"
-          label={Strings.logo}
-          getValueFromEvent={(event) => event?.fileList}
-          rules={[{ required: true, message: Strings.requiredLogo }]}
-        >
-          <Upload
-            maxCount={1}
-            accept="image/*"
-            listType="picture-card"
-            onPreview={handleOnPreview}
-            onChange={handleChange}
-            fileList={fileList}
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="email"
+            rules={[
+              { required: true, message: Strings.requiredEmail },
+              { type: "email", message: Strings.requiredValidEmailAddress },
+              { max: 60 },
+            ]}
+            className="flex-grow"
           >
-            {uploadButton}
-          </Upload>
-        </Form.Item>
+            <Input
+              size="large"
+              maxLength={60}
+              addonBefore={<MailOutlined />}
+              placeholder={Strings.email}
+            />
+          </Form.Item>
+          <Tooltip title="Official company email address.">
+            <QuestionCircleOutlined className="h-9 mb-7 ml-2 text-blue-500 text-sm" />
+          </Tooltip>
+        </div>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="logo"
+            label={Strings.logo}
+            getValueFromEvent={(event) => event?.fileList}
+            rules={[{ required: true, message: Strings.requiredLogo }]}
+          >
+            <div className="flex items-center">
+              <Upload
+                maxCount={1}
+                accept="image/*"
+                listType="picture-card"
+                onPreview={handleOnPreview}
+                onChange={handleChange}
+                fileList={fileList}
+              >
+                {uploadButton}
+              </Upload>
+              <Tooltip title="Upload the company logo in image format.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
+          </Form.Item>
+        </div>
+
         <Form.Item>
           {previewImage && (
             <Image

--- a/src/pages/company/components/UpdateCompanyForm.tsx
+++ b/src/pages/company/components/UpdateCompanyForm.tsx
@@ -108,7 +108,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.companyName}
             />
           </Form.Item>
-          <Tooltip title="Legal name of the company">
+          <Tooltip title={Strings.companyNameTooltip}>
             <QuestionCircleOutlined className="h-9 mr-2 text-blue-500 text-sm" />
           </Tooltip>
           <Form.Item
@@ -134,7 +134,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               }
             />
           </Form.Item>
-          <Tooltip title="The RFC (Federal Taxpayer Registry) must consist of 12 characters for individuals or 13 characters for legal entities. It includes letters and numbers: the first letters correspond to the name or business name, followed by the date of incorporation or birth, and a verification digit. Ensure it matches the official format.">
+          <Tooltip title={Strings.rfcTooltip}>
             <QuestionCircleOutlined className="ml-2 h-9 text-blue-500 text-sm" />
           </Tooltip>
         </div>
@@ -153,7 +153,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.companyAddress}
             />
           </Form.Item>
-          <Tooltip title="Complete address of the company, including street and city.">
+          <Tooltip title={Strings.addressTooltip}>
             <QuestionCircleOutlined className="mb-6 ml-2 text-blue-500 text-sm" />
           </Tooltip>
         </div>
@@ -174,7 +174,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.contact}
             />
           </Form.Item>
-          <Tooltip title="Name of the primary contact person.">
+          <Tooltip title={Strings.contactNameTooltip}>
             <QuestionCircleOutlined className="h-9 ml-1 mr-1.5 text-blue-500 text-sm" />
           </Tooltip>
           <Form.Item
@@ -192,7 +192,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.position}
             />
           </Form.Item>
-          <Tooltip title="Job position of the contact person.">
+          <Tooltip title={Strings.positionTooltip}>
             <QuestionCircleOutlined className="h-9 ml-1.5  text-blue-500 text-sm" />
           </Tooltip>
         </div>
@@ -208,7 +208,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.phone}
             />
           </Form.Item>
-          <Tooltip title="Company's landline number.">
+          <Tooltip title={Strings.phoneTooltip}>
             <QuestionCircleOutlined className="h-9 ml-1.5 mr-1.5  text-blue-500 text-sm" />
           </Tooltip>
           <Form.Item name="extension">
@@ -219,7 +219,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.extension}
             />
           </Form.Item>
-          <Tooltip title="Extension for the phone number (if applicable).">
+          <Tooltip title={Strings.extensionTooltip}>
             <QuestionCircleOutlined className="h-9 ml-1.5 mr-1.5  text-blue-500 text-sm" />
           </Tooltip>
           <Form.Item
@@ -233,7 +233,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.cellular}
             />
           </Form.Item>
-          <Tooltip title="Primary mobile phone number.">
+          <Tooltip title={Strings.cellularTooltip}>
             <QuestionCircleOutlined className="h-9 ml-1.5  text-blue-500 text-sm" />
           </Tooltip>
         </div>
@@ -254,7 +254,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               placeholder={Strings.email}
             />
           </Form.Item>
-          <Tooltip title="Official company email address.">
+          <Tooltip title={Strings.emailTooltip}>
             <QuestionCircleOutlined className="h-9 mb-7 ml-2 text-blue-500 text-sm" />
           </Tooltip>
         </div>
@@ -276,7 +276,7 @@ const UpdateCompanyForm = ({ form }: FormProps) => {
               >
                 {uploadButton}
               </Upload>
-              <Tooltip title="Upload the company logo in image format.">
+              <Tooltip title={Strings.logoTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -317,4 +317,19 @@ export default class Strings {
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+// Register / Update Company Tooltips
+static companyNameTooltip = "Legal name of the company";
+static rfcTooltip = "The RFC (Federal Taxpayer Registry) must consist of 12 characters for individuals or 13 characters for legal entities. It includes letters and numbers: the first letters correspond to the name or business name, followed by the date of incorporation or birth, and a verification digit. Ensure it matches the official format.";
+static addressTooltip = "Complete address of the company, including street and city.";
+static contactNameTooltip = "Name of the primary contact person.";
+static positionTooltip = "Job position of the contact person.";
+static phoneTooltip = "Company's landline number.";
+static extensionTooltip = "Extension for the phone number (if applicable).";
+static cellularTooltip = "Primary mobile phone number.";
+static emailTooltip = "Official company email address.";
+static logoTooltip = "Upload the company logo in image format.";
+
+
+
 }


### PR DESCRIPTION
### Feature / Bug Description
- Add tooltips to the Create / Update company forms. 

### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design 

### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-6)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/df9eeee1-641e-4393-9374-2f9ba586006e)
![image](https://github.com/user-attachments/assets/000ff525-469a-473f-b71c-6d87d792a987)

