### PR TITLE
KAN - 12 Add tooltips  to the Create-Update priority forms

### DIFF
--- a/src/pages/priority/components/RegisterPriorityForm.tsx
+++ b/src/pages/priority/components/RegisterPriorityForm.tsx
@@ -30,7 +30,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
                 addonBefore={<CiBarcode />}
                 placeholder={Strings.code}
               />
-              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+              <Tooltip title={Strings.priorityCodeTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -51,7 +51,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
                 addonBefore={<BsCardText />}
                 placeholder={Strings.description}
               />
-              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+              <Tooltip title={Strings.priorityDescriptionTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -70,7 +70,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
               addonBefore={<AiOutlineFieldNumber />}
               placeholder={Strings.daysNumber}
             />
-            <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+            <Tooltip title={Strings.priorityDaysNumberTooltip}>
               <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
             </Tooltip>
           </div>

--- a/src/pages/priority/components/RegisterPriorityForm.tsx
+++ b/src/pages/priority/components/RegisterPriorityForm.tsx
@@ -1,8 +1,9 @@
-import { Form, FormInstance, Input, InputNumber } from "antd";
+import { Form, FormInstance, Input, InputNumber, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
 import { AiOutlineFieldNumber } from "react-icons/ai";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -22,12 +23,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
             ]}
             className="mr-1"
           >
-            <Input
-              size="large"
-              maxLength={4}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.code}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={4}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="description"
@@ -38,12 +44,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
             ]}
             className="flex-1"
           >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <Form.Item
@@ -52,12 +63,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
           rules={[{ required: true, message: Strings.requiredDaysNumber }]}
           className="flex-1"
         >
-          <InputNumber
-            size="large"
-            maxLength={3}
-            addonBefore={<AiOutlineFieldNumber />}
-            placeholder={Strings.daysNumber}
-          />
+          <div className="flex items-center">
+            <InputNumber
+              size="large"
+              maxLength={3}
+              addonBefore={<AiOutlineFieldNumber />}
+              placeholder={Strings.daysNumber}
+            />
+            <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+              <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+            </Tooltip>
+          </div>
         </Form.Item>
       </div>
     </Form>

--- a/src/pages/priority/components/UpdatePriorityForm.tsx
+++ b/src/pages/priority/components/UpdatePriorityForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormInstance, Input, InputNumber, Select } from "antd";
+import { Form, FormInstance, Input, InputNumber, Select, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
@@ -9,6 +9,7 @@ import { selectCurrentRowData } from "../../../core/genericReducer";
 import { useEffect, useState } from "react";
 import { Status } from "../../../data/status/status";
 import { useGetStatusMutation } from "../../../services/statusService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -30,10 +31,12 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
       label: status.statusName,
     }));
   };
+
   useEffect(() => {
     handleGetData();
     form.setFieldsValue({ ...rowData });
   }, []);
+
   return (
     <Form form={form}>
       <div className="flex flex-col">
@@ -50,12 +53,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             ]}
             className="mr-1"
           >
-            <Input
-              size="large"
-              maxLength={4}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.code}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={4}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="priorityDescription"
@@ -66,12 +74,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             ]}
             className="flex-1"
           >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <div className="flex flex-wrap">
@@ -81,12 +94,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             rules={[{ required: true, message: Strings.requiredDaysNumber }]}
             className="mr-1"
           >
-            <InputNumber
-              size="large"
-              maxLength={3}
-              addonBefore={<AiOutlineFieldNumber />}
-              placeholder={Strings.daysNumber}
-            />
+            <div className="flex items-center">
+              <InputNumber
+                size="large"
+                maxLength={3}
+                addonBefore={<AiOutlineFieldNumber />}
+                placeholder={Strings.daysNumber}
+              />
+              <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item name="status" className="w-60">
             <Select size="large" options={statusOptions()} />
@@ -96,5 +114,4 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
     </Form>
   );
 };
-
 export default UpdatePriorityForm;

--- a/src/pages/priority/components/UpdatePriorityForm.tsx
+++ b/src/pages/priority/components/UpdatePriorityForm.tsx
@@ -60,7 +60,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<CiBarcode />}
                 placeholder={Strings.code}
               />
-              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+              <Tooltip title={Strings.priorityCodeTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -81,7 +81,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<BsCardText />}
                 placeholder={Strings.description}
               />
-              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+              <Tooltip title={Strings.priorityDescriptionTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -101,7 +101,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<AiOutlineFieldNumber />}
                 placeholder={Strings.daysNumber}
               />
-              <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+              <Tooltip title={Strings.priorityDaysNumberTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -317,4 +317,11 @@ export default class Strings {
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+    // Register Priority Form Tooltips
+    static priorityCodeTooltip = "A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.";
+    static priorityDescriptionTooltip = "A brief description of the priority. Use clear, concise language. Maximum 50 characters.";
+    static priorityDaysNumberTooltip = "The number of days associated with this priority. Must be a positive number.";
+
+  
 }


### PR DESCRIPTION
### Feature / Bug Description
Add tooltips  to the Create-Update priority forms

### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design

### Notes
n/a
### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-12)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/90f6086b-18ab-48dd-b37a-af6049dbc9c9)
![image](https://github.com/user-attachments/assets/8e54ffba-21a3-4d01-b1d5-7865c8e7e5c1)

