### PR TITLE
KAN-15 Add tooltips to the Create-Update User forms

### DIFF
--- a/src/pages/cardtypes/components/RegisterCardTypeForm.tsx
+++ b/src/pages/cardtypes/components/RegisterCardTypeForm.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   InputNumber,
   Select,
+  Tooltip,
 } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
@@ -22,7 +23,9 @@ import { CardTypesCatalog } from "../../../data/cardtypes/cardTypes";
 import { IoHeadsetOutline } from "react-icons/io5";
 import { GoDeviceCameraVideo } from "react-icons/go";
 import { useGetCardTypesCatalogsMutation } from "../../../services/CardTypesService";
-type Color = Extract<GetProp<ColorPickerProps, 'value'>, string | { cleared: any }>;
+import { QuestionCircleOutlined } from "@ant-design/icons";
+
+type Color = Extract<GetProp<ColorPickerProps, "value">, string | { cleared: any }>;
 
 interface FormProps {
   form: FormInstance;
@@ -51,6 +54,7 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
     setResponsibles(response1);
     setCatalogs(response2);
   };
+
   useEffect(() => {
     handleGetData();
   }, []);
@@ -67,10 +71,12 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
       label: `${catalog.cardTypeMethodologyName} - ${catalog.cardTypeMethodology}`,
     }));
   };
+
   return (
     <Form form={form}>
       <div className="flex flex-col">
-        <div className="flex flex-row justify-between flex-wrap">
+        {/* Section: Card Type Methodology and Name */}
+        <div className="flex flex-row justify-between flex-wrap items-center">
           <Form.Item
             validateFirst
             rules={[{ required: true, message: Strings.requiredMethodology }]}
@@ -83,6 +89,9 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
               options={catalogsOptions()}
             />
           </Form.Item>
+          <Tooltip title={Strings.cardTypeMethodologyTooltip}>
+            <QuestionCircleOutlined className="mb-6 ml-1 mr-2 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="name"
             validateFirst
@@ -99,23 +108,36 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.cardTypeNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="description"
-          validateFirst
-          rules={[
-            { required: true, message: Strings.requiredDescription },
-            { max: 100 },
-          ]}
-        >
-          <Input
-            size="large"
-            maxLength={100}
-            addonBefore={<BsCardText />}
-            placeholder={Strings.description}
-          />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
+
+        {/* Section: Description */}
+        <div className="flex items-center">
+          <Form.Item
+            name="description"
+            validateFirst
+            rules={[
+              { required: true, message: Strings.requiredDescription },
+              { max: 100 },
+            ]}
+            className="flex-grow"
+          >
+            <Input
+              size="large"
+              maxLength={100}
+              addonBefore={<BsCardText />}
+              placeholder={Strings.description}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.cardTypeDescriptionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
+
+        {/* Section: Color and Responsible */}
+        <div className="flex flex-row flex-wrap items-center">
           <Form.Item
             name="color"
             validateFirst
@@ -128,6 +150,9 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
               </Button>
             </ColorPicker>
           </Form.Item>
+          <Tooltip title={Strings.cardTypeColorTooltip}>
+            <QuestionCircleOutlined className="mb-6 mr-2 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="responsableId"
             validateFirst
@@ -138,13 +163,17 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
               size="large"
               placeholder={Strings.responsible}
               options={responsibleOptions()}
-              className=""
             />
           </Form.Item>
+          <Tooltip title={Strings.responsibleTooltip}>
+            <QuestionCircleOutlined className="mb-6 ml-2 text-sm text-blue-500" />
+          </Tooltip>
         </div>
+
+        {/* Section: At Creation */}
         <h1 className="font-semibold">{Strings.atCreation}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex items-center">
             <Form.Item name="quantityPicturesCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -153,8 +182,11 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesCreateTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityVideosCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -163,7 +195,9 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityVideos}
               />
             </Form.Item>
-
+            <Tooltip title={Strings.quantityVideosCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6  mr-2 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="videosDurationCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -172,8 +206,11 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityAudiosCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -182,11 +219,10 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityAudios}
               />
             </Form.Item>
-            <Form.Item
-              name="audiosDurationCreate"
-              validateFirst
-              className="mr-2"
-            >
+            <Tooltip title={Strings.quantityAudiosCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+            <Form.Item name="audiosDurationCreate" validateFirst>
               <InputNumber
                 size="large"
                 maxLength={10}
@@ -194,11 +230,16 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
         </div>
+
+        {/* Section: At Provisional Solution */}
         <h1 className="font-semibold">{Strings.atProvisionalSolution}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex items-center">
             <Form.Item name="quantityPicturesPs" validateFirst>
               <InputNumber
                 size="large"
@@ -207,16 +248,22 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesPsTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityVideosPs" validateFirst>
               <InputNumber
                 size="large"
                 max={255}
                 addonBefore={<GoDeviceCameraVideo />}
-                placeholder={Strings.videosCreatePs}
+                placeholder={Strings.quantityVideos}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityVideosPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2  mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="videosDurationPs" validateFirst>
               <InputNumber
                 size="large"
@@ -225,17 +272,23 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationPsTooltip}>
+              <QuestionCircleOutlined className="ml-2  mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityAudiosPs" validateFirst>
               <InputNumber
                 size="large"
                 max={255}
                 addonBefore={<IoHeadsetOutline />}
-                placeholder={Strings.audiosCreatePs}
+                placeholder={Strings.quantityAudios}
               />
             </Form.Item>
-            <Form.Item name="audiosDurationPs" validateFirst className="mr-2">
+            <Tooltip title={Strings.quantityAudiosPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 text-sm mb-6  text-blue-500" />
+            </Tooltip>
+            <Form.Item name="audiosDurationPs" validateFirst>
               <InputNumber
                 size="large"
                 maxLength={10}
@@ -243,11 +296,16 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 text-sm mb-6  text-blue-500" />
+            </Tooltip>
           </div>
         </div>
+
+        {/* Section: At Definitive Solution */}
         <h1 className="font-semibold">{Strings.atDefinitiveSolution}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex items-center">
             <Form.Item name="quantityPicturesClose" validateFirst>
               <InputNumber
                 size="large"
@@ -256,8 +314,11 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesCloseTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityVideosClose" validateFirst>
               <InputNumber
                 size="large"
@@ -266,6 +327,9 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityVideos}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityVideosCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="videosDurationClose" validateFirst>
               <InputNumber
                 size="large"
@@ -274,8 +338,11 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+          <div className="flex items-center gap-1">
             <Form.Item name="quantityAudiosClose" validateFirst>
               <InputNumber
                 size="large"
@@ -284,11 +351,10 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityAudios}
               />
             </Form.Item>
-            <Form.Item
-              name="audiosDurationClose"
-              validateFirst
-              className="mr-2"
-            >
+            <Tooltip title={Strings.quantityAudiosCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-sm text-blue-500" />
+            </Tooltip>
+            <Form.Item name="audiosDurationClose" validateFirst>
               <InputNumber
                 size="large"
                 maxLength={10}
@@ -296,11 +362,13 @@ const RegisterCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
         </div>
       </div>
     </Form>
   );
 };
-
 export default RegisterCardTypeForm;

--- a/src/pages/cardtypes/components/UpdateCardTypeForm.tsx
+++ b/src/pages/cardtypes/components/UpdateCardTypeForm.tsx
@@ -8,6 +8,7 @@ import {
   Input,
   InputNumber,
   Select,
+  Tooltip,
 } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
@@ -26,7 +27,12 @@ import { GoDeviceCameraVideo } from "react-icons/go";
 import { IoHeadsetOutline } from "react-icons/io5";
 import { useGetStatusMutation } from "../../../services/statusService";
 import { Status } from "../../../data/status/status";
-type Color = Extract<GetProp<ColorPickerProps, 'value'>, string | { cleared: any }>;
+import { QuestionCircleOutlined } from "@ant-design/icons";
+
+type Color = Extract<
+  GetProp<ColorPickerProps, "value">,
+  string | { cleared: any }
+>;
 
 interface FormProps {
   form: FormInstance;
@@ -104,22 +110,31 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.cardTypeNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="description"
-          validateFirst
-          rules={[
-            { required: true, message: Strings.requiredDescription },
-            { max: 100 },
-          ]}
-        >
-          <Input
-            size="large"
-            maxLength={100}
-            addonBefore={<BsCardText />}
-            placeholder={Strings.description}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="description"
+            validateFirst
+            rules={[
+              { required: true, message: Strings.requiredDescription },
+              { max: 100 },
+            ]}
+            className="flex-grow"
+          >
+            <Input
+              size="large"
+              maxLength={100}
+              addonBefore={<BsCardText />}
+              placeholder={Strings.description}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.cardTypeDescriptionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="color"
@@ -138,6 +153,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
               </Button>
             </ColorPicker>
           </Form.Item>
+          <Tooltip title={Strings.cardTypeColorTooltip}>
+            <QuestionCircleOutlined className="ml-0 mr-3 mb-6 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="responsableId"
             validateFirst
@@ -151,10 +169,13 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
               className=""
             />
           </Form.Item>
+          <Tooltip title={Strings.responsibleTooltip}>
+            <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
         <h1 className="font-semibold">{Strings.atCreation}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex">
             <Form.Item name="quantityPicturesCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -163,6 +184,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesCreateTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
           <div className="flex gap-1">
             <Form.Item name="quantityVideosCreate" validateFirst>
@@ -173,7 +197,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityVideos}
               />
             </Form.Item>
-
+            <Tooltip title={Strings.quantityVideosCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="videosDurationCreate" validateFirst>
               <InputNumber
                 size="large"
@@ -182,6 +208,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
           <div className="flex gap-1">
             <Form.Item name="quantityAudiosCreate" validateFirst>
@@ -192,6 +221,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityAudios}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityAudiosCreateTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item
               name="audiosDurationCreate"
               validateFirst
@@ -204,11 +236,14 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationCreateTooltip}>
+              <QuestionCircleOutlined className="mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
         </div>
         <h1 className="font-semibold">{Strings.atProvisionalSolution}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex">
             <Form.Item name="quantityPicturesPs" validateFirst>
               <InputNumber
                 size="large"
@@ -217,6 +252,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesPsTooltip}>
+              <QuestionCircleOutlined className="ml-3 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
           <div className="flex gap-1">
             <Form.Item name="quantityVideosPs" validateFirst>
@@ -227,6 +265,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.videosCreatePs}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityVideosPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="videosDurationPs" validateFirst>
               <InputNumber
                 size="large"
@@ -235,6 +276,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
           <div className="flex gap-1">
             <Form.Item name="quantityAudiosPs" validateFirst>
@@ -245,6 +289,9 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.audiosCreatePs}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityAudiosPsTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
             <Form.Item name="audiosDurationPs" validateFirst className="mr-2">
               <InputNumber
                 size="large"
@@ -253,11 +300,14 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationPsTooltip}>
+              <QuestionCircleOutlined className="ml-0 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
         </div>
         <h1 className="font-semibold">{Strings.atDefinitiveSolution}</h1>
         <div className="flex flex-col">
-          <div>
+          <div className="flex items-center w-full">
             <Form.Item name="quantityPicturesClose" validateFirst>
               <InputNumber
                 size="large"
@@ -266,8 +316,12 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityPictures}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityPicturesCloseTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+
+          <div className="flex gap-1 items-center">
             <Form.Item name="quantityVideosClose" validateFirst>
               <InputNumber
                 size="large"
@@ -276,6 +330,10 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityVideos}
               />
             </Form.Item>
+            <Tooltip title={Strings.quantityVideosCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+
             <Form.Item name="videosDurationClose" validateFirst>
               <InputNumber
                 size="large"
@@ -284,8 +342,12 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.videosDurationCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
-          <div className="flex gap-1">
+
+          <div className="flex gap-1 items-center">
             <Form.Item name="quantityAudiosClose" validateFirst>
               <InputNumber
                 size="large"
@@ -294,11 +356,11 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.quantityAudios}
               />
             </Form.Item>
-            <Form.Item
-              name="audiosDurationClose"
-              validateFirst
-              className="mr-2"
-            >
+            <Tooltip title={Strings.quantityAudiosCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+
+            <Form.Item name="audiosDurationClose" validateFirst>
               <InputNumber
                 size="large"
                 maxLength={10}
@@ -306,11 +368,19 @@ const UpdateCardTypeForm = ({ form }: FormProps) => {
                 placeholder={Strings.durationInSeconds}
               />
             </Form.Item>
+            <Tooltip title={Strings.audiosDurationCloseTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </div>
         </div>
-        <Form.Item className="w-60" name="status">
+            <div className="flex">
+            <Form.Item className="w-60" name="status">
           <Select size="large" options={statusOptions()} />
         </Form.Item>
+        <Tooltip title={Strings.statusCardTypeTooltip}>
+              <QuestionCircleOutlined className="ml-3.5 mr-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+            </div>
       </div>
     </Form>
   );

--- a/src/pages/priority/components/RegisterPriorityForm.tsx
+++ b/src/pages/priority/components/RegisterPriorityForm.tsx
@@ -30,7 +30,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
                 addonBefore={<CiBarcode />}
                 placeholder={Strings.code}
               />
-              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+              <Tooltip title={Strings.priorityCodeTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -51,7 +51,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
                 addonBefore={<BsCardText />}
                 placeholder={Strings.description}
               />
-              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+              <Tooltip title={Strings.priorityDescriptionTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -70,7 +70,7 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
               addonBefore={<AiOutlineFieldNumber />}
               placeholder={Strings.daysNumber}
             />
-            <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+            <Tooltip title={Strings.priorityDaysNumberTooltip}>
               <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
             </Tooltip>
           </div>

--- a/src/pages/priority/components/RegisterPriorityForm.tsx
+++ b/src/pages/priority/components/RegisterPriorityForm.tsx
@@ -1,8 +1,9 @@
-import { Form, FormInstance, Input, InputNumber } from "antd";
+import { Form, FormInstance, Input, InputNumber, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
 import { AiOutlineFieldNumber } from "react-icons/ai";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -22,12 +23,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
             ]}
             className="mr-1"
           >
-            <Input
-              size="large"
-              maxLength={4}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.code}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={4}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="description"
@@ -38,12 +44,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
             ]}
             className="flex-1"
           >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <Form.Item
@@ -52,12 +63,17 @@ const RegisterPriorityForm = ({ form }: FormProps) => {
           rules={[{ required: true, message: Strings.requiredDaysNumber }]}
           className="flex-1"
         >
-          <InputNumber
-            size="large"
-            maxLength={3}
-            addonBefore={<AiOutlineFieldNumber />}
-            placeholder={Strings.daysNumber}
-          />
+          <div className="flex items-center">
+            <InputNumber
+              size="large"
+              maxLength={3}
+              addonBefore={<AiOutlineFieldNumber />}
+              placeholder={Strings.daysNumber}
+            />
+            <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+              <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+            </Tooltip>
+          </div>
         </Form.Item>
       </div>
     </Form>

--- a/src/pages/priority/components/UpdatePriorityForm.tsx
+++ b/src/pages/priority/components/UpdatePriorityForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormInstance, Input, InputNumber, Select } from "antd";
+import { Form, FormInstance, Input, InputNumber, Select, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
@@ -9,6 +9,7 @@ import { selectCurrentRowData } from "../../../core/genericReducer";
 import { useEffect, useState } from "react";
 import { Status } from "../../../data/status/status";
 import { useGetStatusMutation } from "../../../services/statusService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -30,10 +31,12 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
       label: status.statusName,
     }));
   };
+
   useEffect(() => {
     handleGetData();
     form.setFieldsValue({ ...rowData });
   }, []);
+
   return (
     <Form form={form}>
       <div className="flex flex-col">
@@ -50,12 +53,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             ]}
             className="mr-1"
           >
-            <Input
-              size="large"
-              maxLength={4}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.code}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={4}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item
             name="priorityDescription"
@@ -66,12 +74,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             ]}
             className="flex-1"
           >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
+            <div className="flex items-center">
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+                <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
         </div>
         <div className="flex flex-wrap">
@@ -81,12 +94,17 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
             rules={[{ required: true, message: Strings.requiredDaysNumber }]}
             className="mr-1"
           >
-            <InputNumber
-              size="large"
-              maxLength={3}
-              addonBefore={<AiOutlineFieldNumber />}
-              placeholder={Strings.daysNumber}
-            />
+            <div className="flex items-center">
+              <InputNumber
+                size="large"
+                maxLength={3}
+                addonBefore={<AiOutlineFieldNumber />}
+                placeholder={Strings.daysNumber}
+              />
+              <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+                <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
+              </Tooltip>
+            </div>
           </Form.Item>
           <Form.Item name="status" className="w-60">
             <Select size="large" options={statusOptions()} />
@@ -96,5 +114,4 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
     </Form>
   );
 };
-
 export default UpdatePriorityForm;

--- a/src/pages/priority/components/UpdatePriorityForm.tsx
+++ b/src/pages/priority/components/UpdatePriorityForm.tsx
@@ -60,7 +60,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<CiBarcode />}
                 placeholder={Strings.code}
               />
-              <Tooltip title="A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.">
+              <Tooltip title={Strings.priorityCodeTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -81,7 +81,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<BsCardText />}
                 placeholder={Strings.description}
               />
-              <Tooltip title="A brief description of the priority. Use clear, concise language. Maximum 50 characters.">
+              <Tooltip title={Strings.priorityDescriptionTooltip}>
                 <QuestionCircleOutlined className="ml-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>
@@ -101,7 +101,7 @@ const UpdatePriorityForm = ({ form }: FormProps) => {
                 addonBefore={<AiOutlineFieldNumber />}
                 placeholder={Strings.daysNumber}
               />
-              <Tooltip title="The number of days associated with this priority. Must be a positive number.">
+              <Tooltip title={Strings.priorityDaysNumberTooltip}>
                 <QuestionCircleOutlined className="ml-2 mr-2 text-blue-500 text-sm" />
               </Tooltip>
             </div>

--- a/src/pages/user/components/RegisterSiteUserForm.tsx
+++ b/src/pages/user/components/RegisterSiteUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -6,6 +6,7 @@ import { validateEmail } from "../../../utils/Extensions";
 import { useEffect, useState } from "react";
 import { Role } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -49,6 +50,10 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.userNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+
           <Form.Item
             name="email"
             validateFirst
@@ -65,6 +70,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.email}
             />
           </Form.Item>
+          <Tooltip title={Strings.emailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
@@ -88,6 +96,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.passwordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="confirmPassword"
             validateFirst
@@ -100,7 +111,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
                   if (!value || getFieldValue("password") === value) {
                     return Promise.resolve();
                   }
-                  return Promise.reject(new Error(Strings.passwordsDoNotMatch));
+                  return Promise.reject(
+                    new Error(Strings.passwordsDoNotMatch)
+                  );
                 },
               }),
             ]}
@@ -111,10 +124,11 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.confirmPassword}
             />
           </Form.Item>
+          <Tooltip title={Strings.confirmPasswordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item name="siteId" className="hidden">
-          <Input />
-        </Form.Item>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="uploadCardDataWithDataNet"
@@ -123,6 +137,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
             className="mr-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
           <Form.Item
             name="uploadCardEvidenceWithDataNet"
@@ -131,26 +148,34 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
             className="flex-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
         </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="roles"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="flex-1"
+          >
+            <Select
+              mode="multiple"
+              size="large"
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
       </div>
     </Form>
   );

--- a/src/pages/user/components/RegisterUserForm.tsx
+++ b/src/pages/user/components/RegisterUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -8,6 +8,7 @@ import { Role } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
 import { Site } from "../../../data/site/site";
 import { useGetSitesMutation } from "../../../services/siteService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -70,6 +71,10 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.userNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+
           <Form.Item
             name="email"
             validateFirst
@@ -86,6 +91,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.email}
             />
           </Form.Item>
+          <Tooltip title={Strings.emailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
@@ -109,6 +117,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.passwordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="confirmPassword"
             validateFirst
@@ -132,35 +143,44 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.confirmPassword}
             />
           </Form.Item>
+          <Tooltip title={Strings.confirmPasswordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          label={
-            <p>
-              {Strings.site} ({Strings.rfc})
-            </p>
-          }
-          name="siteId"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredSite }]}
-          className="mr-1"
-        >
-          <Select
-            size="large"
-            placeholder={Strings.site}
-            value={selectedSite}
-            onChange={setSelectedSite}
-            options={siteOptions()}
-            showSearch
-            filterOption={(input, option) => {
-              if (!option) {
-                return false;
-              }
-              return option.labelText
-                .toLowerCase()
-                .includes(input.toLowerCase());
-            }}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            label={
+              <p>
+                {Strings.site} ({Strings.rfc})
+              </p>
+            }
+            name="siteId"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredSite }]}
+            className="flex-grow"
+          >
+            <Select
+              size="large"
+              placeholder={Strings.site}
+              value={selectedSite}
+              onChange={setSelectedSite}
+              options={siteOptions()}
+              showSearch
+              filterOption={(input, option) => {
+                if (!option) {
+                  return false;
+                }
+                return option.labelText
+                  ?.toLowerCase()
+                  .includes(input.toLowerCase());
+              }}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2  text-sm text-blue-500" />
+          </Tooltip>
+        </div>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="uploadCardDataWithDataNet"
@@ -169,6 +189,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
             className="mr-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
           <Form.Item
             name="uploadCardEvidenceWithDataNet"
@@ -177,26 +200,34 @@ const RegisterUserForm = ({ form }: FormProps) => {
             className="flex-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
         </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="roles"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="flex-1"
+          >
+            <Select
+              mode="multiple"
+              size="large"
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
       </div>
     </Form>
   );

--- a/src/pages/user/components/UpdateSiteUserForm.tsx
+++ b/src/pages/user/components/UpdateSiteUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -8,6 +8,7 @@ import { Role, UserUpdateForm } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
 import { useAppSelector } from "../../../core/store";
 import { selectCurrentRowData } from "../../../core/genericReducer";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -41,131 +42,159 @@ const UpdateSiteUserForm = ({ form }: FormProps) => {
 
   return (
     <Form form={form} layout="vertical">
-      <div className="flex flex-col">
-        <div className="flex flex-row flex-wrap">
-          <Form.Item className="hidden" name="id">
-            <Input />
-          </Form.Item>
-          <Form.Item
-            name="name"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredUserName },
-              { max: 50 },
-              { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
-            ]}
-            className="mr-1 flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<FaRegUser />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="email"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredEmail },
-              { validator: validateEmail },
-            ]}
-            className="flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={60}
-              addonBefore={<MailOutlined />}
-              placeholder={Strings.email}
-            />
-          </Form.Item>
+      <div className="flex flex-col gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center">
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredUserName },
+                { max: 50 },
+                { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
+              ]}
+              className="w-full"
+            >
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<FaRegUser />}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.userNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center">
+            <Form.Item
+              name="email"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredEmail },
+                { validator: validateEmail },
+              ]}
+              className="w-full"
+            >
+              <Input
+                size="large"
+                maxLength={60}
+                addonBefore={<MailOutlined />}
+                placeholder={Strings.email}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.emailTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
         </div>
-        <div className="flex flex-row flex-wrap">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center">
+            <Form.Item
+              name="password"
+              validateFirst
+              rules={[{ min: 8, message: Strings.passwordLenght }]}
+              className="w-full"
+            >
+              <Input.Password
+                size="large"
+                minLength={8}
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.updatePassword}
+                visibilityToggle={{
+                  visible: isPasswordVisible,
+                  onVisibleChange: setPasswordVisible,
+                }}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.passwordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center">
+            <Form.Item
+              name="confirmPassword"
+              validateFirst
+              dependencies={["password"]}
+              rules={[
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value && getFieldValue("password")) {
+                      return Promise.reject(
+                        new Error(Strings.requiredPassword)
+                      );
+                    }
+                    if (value && getFieldValue("password") !== value) {
+                      return Promise.reject(
+                        new Error(Strings.passwordsDoNotMatch)
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                }),
+              ]}
+              className="w-full"
+            >
+              <Input.Password
+                size="large"
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.confirmPassword}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.confirmPasswordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center gap-2">
+            <Form.Item
+              name="uploadCardDataWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardDataWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center gap-2">
+            <Form.Item
+              name="uploadCardEvidenceWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardEvidenceWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center">
           <Form.Item
-            name="password"
+            name="roles"
             validateFirst
-            rules={[{ min: 8, message: Strings.passwordLenght }]}
-            className="flex-1 mr-1"
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="w-full"
           >
-            <Input.Password
+            <Select
+              mode="multiple"
               size="large"
-              minLength={8}
-              addonBefore={<LockOutlined />}
-              type="password"
-              placeholder={Strings.updatePassword}
-              visibilityToggle={{
-                visible: isPasswordVisible,
-                onVisibleChange: setPasswordVisible,
-              }}
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
             />
           </Form.Item>
-          <Form.Item
-            name="confirmPassword"
-            validateFirst
-            dependencies={["password"]}
-            className="flex-1"
-            rules={[
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value && getFieldValue("password")) {
-                    return Promise.reject(new Error(Strings.requiredPassword));
-                  }
-                  if (value && getFieldValue("password") !== value) {
-                    return Promise.reject(
-                      new Error(Strings.passwordsDoNotMatch)
-                    );
-                  }
-                  return Promise.resolve();
-                },
-              }),
-            ]}
-          >
-            <Input.Password
-              size="large"
-              addonBefore={<LockOutlined />}
-              placeholder={Strings.confirmPassword}
-            />
-          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item name="siteId" className="hidden">
-          <Input />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
-          <Form.Item
-            name="uploadCardDataWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardDataWithDataNet}
-            className="mr-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-          <Form.Item
-            name="uploadCardEvidenceWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardEvidenceWithDataNet}
-            className="flex-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-        </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
         <Form.Item className="hidden" name="status">
           <Input />
         </Form.Item>

--- a/src/pages/user/components/UpdateUserForm.tsx
+++ b/src/pages/user/components/UpdateUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -11,6 +11,7 @@ import { useGetSitesMutation } from "../../../services/siteService";
 import { useGetUsersMutation } from "../../../services/userService";
 import { useAppSelector } from "../../../core/store";
 import { selectCurrentRowData } from "../../../core/genericReducer";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -74,158 +75,194 @@ const UpdateUserForm = ({ form }: FormProps) => {
           <Form.Item className="hidden" name="id">
             <Input />
           </Form.Item>
-          <Form.Item
-            name="name"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredUserName },
-              { max: 50 },
-              { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
-            ]}
-            className="mr-1 flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<FaRegUser />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="email"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredEmail },
-              { validator: validateEmail },
-            ]}
-            className="flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={60}
-              addonBefore={<MailOutlined />}
-              placeholder={Strings.email}
-            />
-          </Form.Item>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredUserName },
+                { max: 50 },
+                { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
+              ]}
+              className="flex-1"
+            >
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<FaRegUser />}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.userNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="email"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredEmail },
+                { validator: validateEmail },
+              ]}
+            >
+              <Input
+                size="large"
+                maxLength={60}
+                addonBefore={<MailOutlined />}
+                placeholder={Strings.email}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.emailTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
         </div>
         <div className="flex flex-row flex-wrap">
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="password"
+              validateFirst
+              rules={[{ min: 8, message: Strings.passwordLenght }]}
+            >
+              <Input.Password
+                size="large"
+                minLength={8}
+                addonBefore={<LockOutlined />}
+                type="password"
+                placeholder={Strings.updatePassword}
+                visibilityToggle={{
+                  visible: isPasswordVisible,
+                  onVisibleChange: setPasswordVisible,
+                }}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.passwordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="confirmPassword"
+              validateFirst
+              dependencies={["password"]}
+              rules={[
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value && getFieldValue("password")) {
+                      return Promise.reject(
+                        new Error(Strings.requiredPassword)
+                      );
+                    }
+                    if (value && getFieldValue("password") !== value) {
+                      return Promise.reject(
+                        new Error(Strings.passwordsDoNotMatch)
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                }),
+              ]}
+            >
+              <Input.Password
+                size="large"
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.confirmPassword}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.confirmPasswordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center flex-1">
           <Form.Item
-            name="password"
+            label={
+              <p>
+                {Strings.site} ({Strings.rfc}) - {Strings.userLicense} -{" "}
+                <span className="rounded-xl p-0.5 text-white bg-gray-600">
+                  Current users
+                </span>{" "}
+                /{" "}
+                <span className="rounded-xl p-0.5 text-white bg-gray-800">
+                  User quantity
+                </span>
+              </p>
+            }
+            name="siteId"
             validateFirst
-            rules={[{ min: 8, message: Strings.passwordLenght }]}
-            className="flex-1 mr-1"
+            rules={[{ required: true, message: Strings.requiredSite }]}
+            className="flex-grow"
           >
-            <Input.Password
+            <Select
               size="large"
-              minLength={8}
-              addonBefore={<LockOutlined />}
-              type="password"
-              placeholder={Strings.updatePassword}
-              visibilityToggle={{
-                visible: isPasswordVisible,
-                onVisibleChange: setPasswordVisible,
+              placeholder={Strings.site}
+              value={selectedSite}
+              onChange={setSelectedSite}
+              options={siteOptions}
+              showSearch
+              filterOption={(input, option) => {
+                if (!option) {
+                  return false;
+                }
+                return option.labelText
+                  .toLowerCase()
+                  .includes(input.toLowerCase());
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
+        <div className="flex flex-row flex-wrap">
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="uploadCardDataWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardDataWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="uploadCardEvidenceWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardEvidenceWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center flex-1">
           <Form.Item
-            name="confirmPassword"
+            name="roles"
             validateFirst
-            dependencies={["password"]}
-            className="flex-1"
-            rules={[
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value && getFieldValue("password")) {
-                    return Promise.reject(new Error(Strings.requiredPassword));
-                  }
-                  if (value && getFieldValue("password") !== value) {
-                    return Promise.reject(
-                      new Error(Strings.passwordsDoNotMatch)
-                    );
-                  }
-                  return Promise.resolve();
-                },
-              }),
-            ]}
+            rules={[{ required: true, message: Strings.requiredRoles }]}
           >
-            <Input.Password
+            <Select
+              mode="multiple"
               size="large"
-              addonBefore={<LockOutlined />}
-              placeholder={Strings.confirmPassword}
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
             />
           </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          label={
-            <p>
-              {Strings.site} ({Strings.rfc}) - {Strings.userLicense} -{" "}
-              <span className="rounded-xl p-0.5 text-white bg-gray-600">
-                Current users
-              </span>{" "}
-              /{" "}
-              <span className="rounded-xl p-0.5 text-white bg-gray-800">
-                User quantity
-              </span>
-            </p>
-          }
-          name="siteId"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredSite }]}
-          className="mr-1"
-        >
-          <Select
-            size="large"
-            placeholder={Strings.site}
-            value={selectedSite}
-            onChange={setSelectedSite}
-            options={siteOptions}
-            showSearch
-            filterOption={(input, option) => {
-              if (!option) {
-                return false;
-              }
-              return option.labelText
-                .toLowerCase()
-                .includes(input.toLowerCase());
-            }}
-          />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
-          <Form.Item
-            name="uploadCardDataWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardDataWithDataNet}
-            className="mr-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-          <Form.Item
-            name="uploadCardEvidenceWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardEvidenceWithDataNet}
-            className="flex-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-        </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
         <Form.Item className="hidden" name="status">
           <Input />
         </Form.Item>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -318,10 +318,37 @@ export default class Strings {
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
 
-    // Register Priority Form Tooltips
+    // Register/ Update Priority Form Tooltips
     static priorityCodeTooltip = "A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.";
     static priorityDescriptionTooltip = "A brief description of the priority. Use clear, concise language. Maximum 50 characters.";
     static priorityDaysNumberTooltip = "The number of days associated with this priority. Must be a positive number.";
 
-  
+    // Register / Update Card-Type Form Tooltips
+    static cardTypeMethodologyTooltip = "Select the methodology associated with this card type.";
+    static cardTypeNameTooltip = "Provide a unique name for the card type. Maximum 45 characters.";
+    static cardTypeDescriptionTooltip = "Briefly describe the purpose of the card type. Maximum 100 characters.";
+    static cardTypeColorTooltip = "Choose a color to visually represent this card type.";
+    static responsibleTooltip = "Select the person responsible for managing this card type.";
+
+    static quantityPicturesCreateTooltip = "Enter the number of pictures required at the creation stage.";
+    static quantityVideosCreateTooltip = "Specify the number of videos required at the creation stage.";
+    static videosDurationCreateTooltip = "Provide the total duration (in seconds) of videos for the creation stage.";
+    static quantityAudiosCreateTooltip = "Specify the number of audio files required at the creation stage.";
+    static audiosDurationCreateTooltip = "Provide the total duration (in seconds) of audio files for the creation stage.";
+
+    static quantityPicturesPsTooltip = "Enter the number of pictures required at the provisional solution stage.";
+    static quantityVideosPsTooltip = "Specify the number of videos required at the provisional solution stage.";
+    static videosDurationPsTooltip = "Provide the total duration (in seconds) of videos for the provisional solution stage.";
+    static quantityAudiosPsTooltip = "Specify the number of audio files required at the provisional solution stage.";
+    static audiosDurationPsTooltip = "Provide the total duration (in seconds) of audio files for the provisional solution stage.";
+
+    static quantityPicturesCloseTooltip = "Enter the number of pictures required at the definitive solution stage.";
+    static quantityVideosCloseTooltip = "Specify the number of videos required at the definitive solution stage.";
+    static videosDurationCloseTooltip = "Provide the total duration (in seconds) of videos for the definitive solution stage.";
+    static quantityAudiosCloseTooltip = "Specify the number of audio files required at the definitive solution stage.";
+    static audiosDurationCloseTooltip = "Provide the total duration (in seconds) of audio files for the definitive solution stage.";  
+
+    static cardTypeStatusTooltip = "Select the current status of the card type. It determines whether the card type is active or inactive in the system.";
+    static statusCardTypeTooltip = "You can change the status of the card type"
+
 }

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -351,4 +351,15 @@ export default class Strings {
     static cardTypeStatusTooltip = "Select the current status of the card type. It determines whether the card type is active or inactive in the system.";
     static statusCardTypeTooltip = "You can change the status of the card type"
 
+        // Register / Update Users Form Tooltips
+    static userNameTooltip = "Enter the full name of the user. Only letters are allowed.";
+    static emailTooltip = "Enter a valid email address for the user.";
+    static passwordTooltip = "Enter a secure password. It must be at least 8 characters long.";
+    static confirmPasswordTooltip = "Confirm the password to ensure it matches the original.";
+    static siteRfcTooltip = "Select the RFC of the site to which the user will be assigned.";
+    static uploadCardDataWithDataNetTooltip = "Enable this option if the user can upload card data using DataNet.";
+    static uploadCardEvidenceWithDataNetTooltip = "Enable this option if the user can upload card evidence using DataNet.";
+    static rolesTooltip = "Select one or more roles to assign to the user.";
+
+
 }

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -317,4 +317,11 @@ export default class Strings {
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+    // Register Priority Form Tooltips
+    static priorityCodeTooltip = "A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.";
+    static priorityDescriptionTooltip = "A brief description of the priority. Use clear, concise language. Maximum 50 characters.";
+    static priorityDaysNumberTooltip = "The number of days associated with this priority. Must be a positive number.";
+
+  
 }


### PR DESCRIPTION
### Feature / Bug Description
-Add tooltips to the Create-Update User forms
### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design

### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-15)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/2042812f-2ce7-419c-a642-70133c5dfb05)
![image](https://github.com/user-attachments/assets/070f3630-5171-4971-86bf-46cc14808781)
