### PR TITLE
KAN 15 Add tooltips to the Create Update Users forms

### DIFF
--- a/src/pages/user/components/RegisterSiteUserForm.tsx
+++ b/src/pages/user/components/RegisterSiteUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -6,6 +6,7 @@ import { validateEmail } from "../../../utils/Extensions";
 import { useEffect, useState } from "react";
 import { Role } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -49,6 +50,10 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.userNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+
           <Form.Item
             name="email"
             validateFirst
@@ -65,6 +70,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.email}
             />
           </Form.Item>
+          <Tooltip title={Strings.emailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
@@ -88,6 +96,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.passwordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="confirmPassword"
             validateFirst
@@ -100,7 +111,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
                   if (!value || getFieldValue("password") === value) {
                     return Promise.resolve();
                   }
-                  return Promise.reject(new Error(Strings.passwordsDoNotMatch));
+                  return Promise.reject(
+                    new Error(Strings.passwordsDoNotMatch)
+                  );
                 },
               }),
             ]}
@@ -111,10 +124,11 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
               placeholder={Strings.confirmPassword}
             />
           </Form.Item>
+          <Tooltip title={Strings.confirmPasswordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item name="siteId" className="hidden">
-          <Input />
-        </Form.Item>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="uploadCardDataWithDataNet"
@@ -123,6 +137,9 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
             className="mr-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
           <Form.Item
             name="uploadCardEvidenceWithDataNet"
@@ -131,26 +148,34 @@ const RegisterSiteUserForm = ({ form }: FormProps) => {
             className="flex-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
         </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="roles"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="flex-1"
+          >
+            <Select
+              mode="multiple"
+              size="large"
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
       </div>
     </Form>
   );

--- a/src/pages/user/components/RegisterUserForm.tsx
+++ b/src/pages/user/components/RegisterUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -8,6 +8,7 @@ import { Role } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
 import { Site } from "../../../data/site/site";
 import { useGetSitesMutation } from "../../../services/siteService";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -70,6 +71,10 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.name}
             />
           </Form.Item>
+          <Tooltip title={Strings.userNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+
           <Form.Item
             name="email"
             validateFirst
@@ -86,6 +91,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.email}
             />
           </Form.Item>
+          <Tooltip title={Strings.emailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
@@ -109,6 +117,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.passwordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
           <Form.Item
             name="confirmPassword"
             validateFirst
@@ -132,35 +143,44 @@ const RegisterUserForm = ({ form }: FormProps) => {
               placeholder={Strings.confirmPassword}
             />
           </Form.Item>
+          <Tooltip title={Strings.confirmPasswordTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          label={
-            <p>
-              {Strings.site} ({Strings.rfc})
-            </p>
-          }
-          name="siteId"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredSite }]}
-          className="mr-1"
-        >
-          <Select
-            size="large"
-            placeholder={Strings.site}
-            value={selectedSite}
-            onChange={setSelectedSite}
-            options={siteOptions()}
-            showSearch
-            filterOption={(input, option) => {
-              if (!option) {
-                return false;
-              }
-              return option.labelText
-                .toLowerCase()
-                .includes(input.toLowerCase());
-            }}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            label={
+              <p>
+                {Strings.site} ({Strings.rfc})
+              </p>
+            }
+            name="siteId"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredSite }]}
+            className="flex-grow"
+          >
+            <Select
+              size="large"
+              placeholder={Strings.site}
+              value={selectedSite}
+              onChange={setSelectedSite}
+              options={siteOptions()}
+              showSearch
+              filterOption={(input, option) => {
+                if (!option) {
+                  return false;
+                }
+                return option.labelText
+                  ?.toLowerCase()
+                  .includes(input.toLowerCase());
+              }}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2  text-sm text-blue-500" />
+          </Tooltip>
+        </div>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="uploadCardDataWithDataNet"
@@ -169,6 +189,9 @@ const RegisterUserForm = ({ form }: FormProps) => {
             className="mr-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
           <Form.Item
             name="uploadCardEvidenceWithDataNet"
@@ -177,26 +200,34 @@ const RegisterUserForm = ({ form }: FormProps) => {
             className="flex-1"
           >
             <Checkbox value={1}>{Strings.enable}</Checkbox>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
           </Form.Item>
         </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
+        <div className="flex items-center w-full">
+          <Form.Item
+            name="roles"
+            validateFirst
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="flex-1"
+          >
+            <Select
+              mode="multiple"
+              size="large"
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
       </div>
     </Form>
   );

--- a/src/pages/user/components/UpdateSiteUserForm.tsx
+++ b/src/pages/user/components/UpdateSiteUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -8,6 +8,7 @@ import { Role, UserUpdateForm } from "../../../data/user/user";
 import { useGetRolesMutation } from "../../../services/roleService";
 import { useAppSelector } from "../../../core/store";
 import { selectCurrentRowData } from "../../../core/genericReducer";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -41,131 +42,159 @@ const UpdateSiteUserForm = ({ form }: FormProps) => {
 
   return (
     <Form form={form} layout="vertical">
-      <div className="flex flex-col">
-        <div className="flex flex-row flex-wrap">
-          <Form.Item className="hidden" name="id">
-            <Input />
-          </Form.Item>
-          <Form.Item
-            name="name"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredUserName },
-              { max: 50 },
-              { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
-            ]}
-            className="mr-1 flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<FaRegUser />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="email"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredEmail },
-              { validator: validateEmail },
-            ]}
-            className="flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={60}
-              addonBefore={<MailOutlined />}
-              placeholder={Strings.email}
-            />
-          </Form.Item>
+      <div className="flex flex-col gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center">
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredUserName },
+                { max: 50 },
+                { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
+              ]}
+              className="w-full"
+            >
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<FaRegUser />}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.userNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center">
+            <Form.Item
+              name="email"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredEmail },
+                { validator: validateEmail },
+              ]}
+              className="w-full"
+            >
+              <Input
+                size="large"
+                maxLength={60}
+                addonBefore={<MailOutlined />}
+                placeholder={Strings.email}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.emailTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
         </div>
-        <div className="flex flex-row flex-wrap">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center">
+            <Form.Item
+              name="password"
+              validateFirst
+              rules={[{ min: 8, message: Strings.passwordLenght }]}
+              className="w-full"
+            >
+              <Input.Password
+                size="large"
+                minLength={8}
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.updatePassword}
+                visibilityToggle={{
+                  visible: isPasswordVisible,
+                  onVisibleChange: setPasswordVisible,
+                }}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.passwordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center">
+            <Form.Item
+              name="confirmPassword"
+              validateFirst
+              dependencies={["password"]}
+              rules={[
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value && getFieldValue("password")) {
+                      return Promise.reject(
+                        new Error(Strings.requiredPassword)
+                      );
+                    }
+                    if (value && getFieldValue("password") !== value) {
+                      return Promise.reject(
+                        new Error(Strings.passwordsDoNotMatch)
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                }),
+              ]}
+              className="w-full"
+            >
+              <Input.Password
+                size="large"
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.confirmPassword}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.confirmPasswordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+          <div className="flex items-center gap-2">
+            <Form.Item
+              name="uploadCardDataWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardDataWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center gap-2">
+            <Form.Item
+              name="uploadCardEvidenceWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardEvidenceWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center">
           <Form.Item
-            name="password"
+            name="roles"
             validateFirst
-            rules={[{ min: 8, message: Strings.passwordLenght }]}
-            className="flex-1 mr-1"
+            rules={[{ required: true, message: Strings.requiredRoles }]}
+            className="w-full"
           >
-            <Input.Password
+            <Select
+              mode="multiple"
               size="large"
-              minLength={8}
-              addonBefore={<LockOutlined />}
-              type="password"
-              placeholder={Strings.updatePassword}
-              visibilityToggle={{
-                visible: isPasswordVisible,
-                onVisibleChange: setPasswordVisible,
-              }}
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
             />
           </Form.Item>
-          <Form.Item
-            name="confirmPassword"
-            validateFirst
-            dependencies={["password"]}
-            className="flex-1"
-            rules={[
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value && getFieldValue("password")) {
-                    return Promise.reject(new Error(Strings.requiredPassword));
-                  }
-                  if (value && getFieldValue("password") !== value) {
-                    return Promise.reject(
-                      new Error(Strings.passwordsDoNotMatch)
-                    );
-                  }
-                  return Promise.resolve();
-                },
-              }),
-            ]}
-          >
-            <Input.Password
-              size="large"
-              addonBefore={<LockOutlined />}
-              placeholder={Strings.confirmPassword}
-            />
-          </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item name="siteId" className="hidden">
-          <Input />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
-          <Form.Item
-            name="uploadCardDataWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardDataWithDataNet}
-            className="mr-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-          <Form.Item
-            name="uploadCardEvidenceWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardEvidenceWithDataNet}
-            className="flex-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-        </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
         <Form.Item className="hidden" name="status">
           <Input />
         </Form.Item>

--- a/src/pages/user/components/UpdateUserForm.tsx
+++ b/src/pages/user/components/UpdateUserForm.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Form, FormInstance, Input, Select } from "antd";
+import { Checkbox, Form, FormInstance, Input, Select, Tooltip } from "antd";
 import { LockOutlined, MailOutlined } from "@ant-design/icons";
 import { FaRegUser } from "react-icons/fa";
 import Strings from "../../../utils/localizations/Strings";
@@ -11,6 +11,7 @@ import { useGetSitesMutation } from "../../../services/siteService";
 import { useGetUsersMutation } from "../../../services/userService";
 import { useAppSelector } from "../../../core/store";
 import { selectCurrentRowData } from "../../../core/genericReducer";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -74,158 +75,194 @@ const UpdateUserForm = ({ form }: FormProps) => {
           <Form.Item className="hidden" name="id">
             <Input />
           </Form.Item>
-          <Form.Item
-            name="name"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredUserName },
-              { max: 50 },
-              { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
-            ]}
-            className="mr-1 flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<FaRegUser />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="email"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredEmail },
-              { validator: validateEmail },
-            ]}
-            className="flex-1"
-          >
-            <Input
-              size="large"
-              maxLength={60}
-              addonBefore={<MailOutlined />}
-              placeholder={Strings.email}
-            />
-          </Form.Item>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredUserName },
+                { max: 50 },
+                { pattern: /^[A-Za-z\s]+$/, message: Strings.onlyLetters },
+              ]}
+              className="flex-1"
+            >
+              <Input
+                size="large"
+                maxLength={50}
+                addonBefore={<FaRegUser />}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.userNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="email"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredEmail },
+                { validator: validateEmail },
+              ]}
+            >
+              <Input
+                size="large"
+                maxLength={60}
+                addonBefore={<MailOutlined />}
+                placeholder={Strings.email}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.emailTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
         </div>
         <div className="flex flex-row flex-wrap">
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="password"
+              validateFirst
+              rules={[{ min: 8, message: Strings.passwordLenght }]}
+            >
+              <Input.Password
+                size="large"
+                minLength={8}
+                addonBefore={<LockOutlined />}
+                type="password"
+                placeholder={Strings.updatePassword}
+                visibilityToggle={{
+                  visible: isPasswordVisible,
+                  onVisibleChange: setPasswordVisible,
+                }}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.passwordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="confirmPassword"
+              validateFirst
+              dependencies={["password"]}
+              rules={[
+                ({ getFieldValue }) => ({
+                  validator(_, value) {
+                    if (!value && getFieldValue("password")) {
+                      return Promise.reject(
+                        new Error(Strings.requiredPassword)
+                      );
+                    }
+                    if (value && getFieldValue("password") !== value) {
+                      return Promise.reject(
+                        new Error(Strings.passwordsDoNotMatch)
+                      );
+                    }
+                    return Promise.resolve();
+                  },
+                }),
+              ]}
+            >
+              <Input.Password
+                size="large"
+                addonBefore={<LockOutlined />}
+                placeholder={Strings.confirmPassword}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.confirmPasswordTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center flex-1">
           <Form.Item
-            name="password"
+            label={
+              <p>
+                {Strings.site} ({Strings.rfc}) - {Strings.userLicense} -{" "}
+                <span className="rounded-xl p-0.5 text-white bg-gray-600">
+                  Current users
+                </span>{" "}
+                /{" "}
+                <span className="rounded-xl p-0.5 text-white bg-gray-800">
+                  User quantity
+                </span>
+              </p>
+            }
+            name="siteId"
             validateFirst
-            rules={[{ min: 8, message: Strings.passwordLenght }]}
-            className="flex-1 mr-1"
+            rules={[{ required: true, message: Strings.requiredSite }]}
+            className="flex-grow"
           >
-            <Input.Password
+            <Select
               size="large"
-              minLength={8}
-              addonBefore={<LockOutlined />}
-              type="password"
-              placeholder={Strings.updatePassword}
-              visibilityToggle={{
-                visible: isPasswordVisible,
-                onVisibleChange: setPasswordVisible,
+              placeholder={Strings.site}
+              value={selectedSite}
+              onChange={setSelectedSite}
+              options={siteOptions}
+              showSearch
+              filterOption={(input, option) => {
+                if (!option) {
+                  return false;
+                }
+                return option.labelText
+                  .toLowerCase()
+                  .includes(input.toLowerCase());
               }}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
+        </div>
+        <div className="flex flex-row flex-wrap">
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="uploadCardDataWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardDataWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardDataWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center flex-1">
+            <Form.Item
+              name="uploadCardEvidenceWithDataNet"
+              valuePropName="checked"
+              label={Strings.uploadCardEvidenceWithDataNet}
+            >
+              <Checkbox value={1}>{Strings.enable}</Checkbox>
+            </Form.Item>
+            <Tooltip title={Strings.uploadCardEvidenceWithDataNetTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+        </div>
+        <div className="flex items-center flex-1">
           <Form.Item
-            name="confirmPassword"
+            name="roles"
             validateFirst
-            dependencies={["password"]}
-            className="flex-1"
-            rules={[
-              ({ getFieldValue }) => ({
-                validator(_, value) {
-                  if (!value && getFieldValue("password")) {
-                    return Promise.reject(new Error(Strings.requiredPassword));
-                  }
-                  if (value && getFieldValue("password") !== value) {
-                    return Promise.reject(
-                      new Error(Strings.passwordsDoNotMatch)
-                    );
-                  }
-                  return Promise.resolve();
-                },
-              }),
-            ]}
+            rules={[{ required: true, message: Strings.requiredRoles }]}
           >
-            <Input.Password
+            <Select
+              mode="multiple"
               size="large"
-              addonBefore={<LockOutlined />}
-              placeholder={Strings.confirmPassword}
+              placeholder={Strings.roles}
+              value={selectedRoles}
+              onChange={setSelectedRoles}
+              options={filteredOptions.map((item) => ({
+                value: item.id,
+                label: item.name,
+              }))}
             />
           </Form.Item>
+          <Tooltip title={Strings.rolesTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+          </Tooltip>
         </div>
-        <Form.Item
-          label={
-            <p>
-              {Strings.site} ({Strings.rfc}) - {Strings.userLicense} -{" "}
-              <span className="rounded-xl p-0.5 text-white bg-gray-600">
-                Current users
-              </span>{" "}
-              /{" "}
-              <span className="rounded-xl p-0.5 text-white bg-gray-800">
-                User quantity
-              </span>
-            </p>
-          }
-          name="siteId"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredSite }]}
-          className="mr-1"
-        >
-          <Select
-            size="large"
-            placeholder={Strings.site}
-            value={selectedSite}
-            onChange={setSelectedSite}
-            options={siteOptions}
-            showSearch
-            filterOption={(input, option) => {
-              if (!option) {
-                return false;
-              }
-              return option.labelText
-                .toLowerCase()
-                .includes(input.toLowerCase());
-            }}
-          />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
-          <Form.Item
-            name="uploadCardDataWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardDataWithDataNet}
-            className="mr-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-          <Form.Item
-            name="uploadCardEvidenceWithDataNet"
-            valuePropName="checked"
-            label={Strings.uploadCardEvidenceWithDataNet}
-            className="flex-1"
-          >
-            <Checkbox value={1}>{Strings.enable}</Checkbox>
-          </Form.Item>
-        </div>
-        <Form.Item
-          name="roles"
-          validateFirst
-          rules={[{ required: true, message: Strings.requiredRoles }]}
-          className="flex-1"
-        >
-          <Select
-            mode="multiple"
-            size="large"
-            placeholder={Strings.roles}
-            value={selectedRoles}
-            onChange={setSelectedRoles}
-            options={filteredOptions.map((item) => ({
-              value: item.id,
-              label: item.name,
-            }))}
-          />
-        </Form.Item>
         <Form.Item className="hidden" name="status">
           <Input />
         </Form.Item>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -317,4 +317,16 @@ export default class Strings {
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+  // Register / Update Users Form Tooltips
+  static userNameTooltip = "Enter the full name of the user. Only letters are allowed.";
+  static emailTooltip = "Enter a valid email address for the user.";
+  static passwordTooltip = "Enter a secure password. It must be at least 8 characters long.";
+  static confirmPasswordTooltip = "Confirm the password to ensure it matches the original.";
+  static siteRfcTooltip = "Select the RFC of the site to which the user will be assigned.";
+  static uploadCardDataWithDataNetTooltip = "Enable this option if the user can upload card data using DataNet.";
+  static uploadCardEvidenceWithDataNetTooltip = "Enable this option if the user can upload card evidence using DataNet.";
+  static rolesTooltip = "Select one or more roles to assign to the user.";
+       
+
 }


### PR DESCRIPTION
### Feature / Bug Description
- Add tooltips to the Create Update Users forms

### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design

### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-15)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/6d656d89-4e9c-40a0-8a61-a70ae7190abc)
![image](https://github.com/user-attachments/assets/5bb806a8-14c1-4bb7-9a76-4058015a0161)

