### PR TITLE
KAN - 8 Add tooltips to the Create Update Site forms

### DIFF
--- a/src/pages/site/components/RegisterSiteForm.tsx
+++ b/src/pages/site/components/RegisterSiteForm.tsx
@@ -10,6 +10,7 @@ import {
   Upload,
   UploadFile,
   UploadProps,
+  Tooltip,
 } from "antd";
 import { MailOutlined } from "@ant-design/icons";
 import { FaRegBuilding } from "react-icons/fa";
@@ -19,6 +20,7 @@ import {
   MdOutlineQrCodeScanner,
 } from "react-icons/md";
 import { SlCompass } from "react-icons/sl";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 import { IoIosContact } from "react-icons/io";
 import { PlusOutlined } from "@ant-design/icons";
 import { BsDiagram3 } from "react-icons/bs";
@@ -118,6 +120,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.companyName}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="rfc"
             validateFirst
@@ -141,11 +147,18 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               }
             />
           </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item name="siteCode" className="w-36">
             <Input size="large" disabled addonBefore={<CiBarcode />} />
           </Form.Item>
+          <Tooltip title={Strings.siteCodeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="siteBusinessName"
             rules={[
@@ -160,8 +173,11 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<IoBusinessOutline />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteBusinessNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <div className="flex justify-between flex-row flex-wrap">
+        <div className="flex justify-between flex-row">
           <Form.Item
             name="siteType"
             rules={[{ required: true, message: Strings.requiredSiteType }]}
@@ -173,6 +189,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<MdOutlineCategory />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteTypeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="latitud"
             rules={[{ required: true, message: Strings.requiredLatitud }]}
@@ -184,6 +204,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<TbWorldLatitude />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteLatitudeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="longitud"
             rules={[{ required: true, message: Strings.requiredLongitud }]}
@@ -195,20 +219,30 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<TbWorldLongitude />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteLongitudeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="address"
-          rules={[
-            { required: true, message: Strings.requiredAddress },
-            { max: 200 },
-          ]}
-        >
-          <Input
-            size="large"
-            addonBefore={<SlCompass />}
-            placeholder={Strings.companyAddress}
-          />
-        </Form.Item>
+        <div className="flex">
+          <Form.Item
+            name="address"
+            className="flex-1"
+            rules={[
+              { required: true, message: Strings.requiredAddress },
+              { max: 200 },
+            ]}
+          >
+            <Input
+              size="large"
+              addonBefore={<SlCompass />}
+              placeholder={Strings.companyAddress}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteAddressTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="contact"
@@ -225,6 +259,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.contact}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteContactTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="position"
             rules={[
@@ -240,8 +278,11 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.position}
             />
           </Form.Item>
+          <Tooltip title={Strings.sitePositionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <div className="flex justify-between flex-row flex-wrap">
+        <div className="flex justify-between flex-row ">
           <Form.Item
             name="phone"
             rules={[{ required: true, message: Strings.requiredPhone }]}
@@ -253,6 +294,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.phone}
             />
           </Form.Item>
+          <Tooltip title={Strings.sitePhoneTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item name="extension">
             <InputNumber
               size="large"
@@ -261,6 +306,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.extension}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteExtensionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="cellular"
             rules={[{ required: true, message: Strings.requiredCellular }]}
@@ -272,23 +321,33 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.cellular}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteCellularTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="email"
-          rules={[
-            { required: true, message: Strings.requiredEmail },
-            { type: "email", message: Strings.requiredValidEmailAddress },
-            { max: 60 },
-          ]}
-        >
-          <Input
-            size="large"
-            maxLength={60}
-            addonBefore={<MailOutlined />}
-            placeholder={Strings.email}
-          />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
+        <div className="flex">
+          <Form.Item
+            name="email"
+            className="flex-1"
+            rules={[
+              { required: true, message: Strings.requiredEmail },
+              { type: "email", message: Strings.requiredValidEmailAddress },
+              { max: 60 },
+            ]}
+          >
+            <Input
+              size="large"
+              maxLength={60}
+              addonBefore={<MailOutlined />}
+              placeholder={Strings.email}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteEmailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
+        <div className="flex flex-row ">
           <Form.Item
             name="dueDate"
             rules={[{ required: true, message: Strings.requiredDueDate }]}
@@ -300,6 +359,10 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.dueDate}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteDueDateTooltip}>
+            <QuestionCircleOutlined className="ml-0.5  mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="monthlyPayment"
             rules={[
@@ -314,6 +377,11 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<FiDollarSign />}
             />
           </Form.Item>
+
+          <Tooltip title={Strings.siteMonthlyPaymentTooltip}>
+            <QuestionCircleOutlined className="ml-0.5 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="currency"
             rules={[{ required: true, message: Strings.requiredCurrency }]}
@@ -325,6 +393,9 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.currency}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteCurrencyTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
         <div className="flex flex-row">
           <Form.Item
@@ -332,7 +403,7 @@ const RegisterSiteForm = ({ form }: FormProps) => {
             rules={[
               { required: true, message: Strings.requiredAppHistoryDays },
             ]}
-            className="mr-10"
+            className="mr-2"
           >
             <InputNumber
               size="large"
@@ -341,24 +412,33 @@ const RegisterSiteForm = ({ form }: FormProps) => {
               addonBefore={<LuHistory />}
             />
           </Form.Item>
+          <Tooltip title={Strings.appHistoryDaysTooltip}>
+            <QuestionCircleOutlined className=" mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="logo"
-          label={Strings.logo}
-          getValueFromEvent={(event) => event?.fileList}
-          rules={[{ required: true, message: Strings.requiredLogo }]}
-        >
-          <Upload
-            maxCount={1}
-            accept="image/*"
-            listType="picture-card"
-            onPreview={handleOnPreview}
-            onChange={handleChange}
-            fileList={fileList}
+        <div className="flex">
+          <Form.Item
+            name="logo"
+            label={Strings.logo}
+            getValueFromEvent={(event) => event?.fileList}
+            rules={[{ required: true, message: Strings.requiredLogo }]}
           >
-            {uploadButton}
-          </Upload>
-        </Form.Item>
+            <Upload
+              maxCount={1}
+              accept="image/*"
+              listType="picture-card"
+              onPreview={handleOnPreview}
+              onChange={handleChange}
+              fileList={fileList}
+            >
+              {uploadButton}
+            </Upload>
+          </Form.Item>
+          <Tooltip title={Strings.siteLogoTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
         <Form.Item>
           {previewImage && (
             <Image

--- a/src/pages/site/components/UpdateSiteForm.tsx
+++ b/src/pages/site/components/UpdateSiteForm.tsx
@@ -10,9 +10,11 @@ import {
   Upload,
   UploadFile,
   UploadProps,
+  Tooltip,
 } from "antd";
 import { MailOutlined } from "@ant-design/icons";
 import { FaRegBuilding } from "react-icons/fa";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 import {
   MdOutlineCategory,
   MdOutlineLocalPhone,
@@ -138,6 +140,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.companyName}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="rfc"
             validateFirst
@@ -161,11 +166,17 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               }
             />
           </Form.Item>
+          <Tooltip title={Strings.siteRfcTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item name="siteCode" className="w-36">
             <Input size="large" disabled addonBefore={<CiBarcode />} />
           </Form.Item>
+          <Tooltip title={Strings.siteCodeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="siteBusinessName"
             rules={[
@@ -180,8 +191,11 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               addonBefore={<IoBusinessOutline />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteBusinessNameTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <div className="flex justify-between flex-row flex-wrap">
+        <div className="flex justify-between flex-row ">
           <Form.Item
             name="siteType"
             rules={[{ required: true, message: Strings.requiredSiteType }]}
@@ -193,6 +207,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               addonBefore={<MdOutlineCategory />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteTypeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="latitud"
             rules={[{ required: true, message: Strings.requiredLatitud }]}
@@ -204,6 +221,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               addonBefore={<TbWorldLatitude />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteLatitudeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="longitud"
             rules={[{ required: true, message: Strings.requiredLongitud }]}
@@ -215,20 +235,29 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               addonBefore={<TbWorldLongitude />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteLongitudeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="address"
-          rules={[
-            { required: true, message: Strings.requiredAddress },
-            { max: 200 },
-          ]}
-        >
-          <Input
-            size="large"
-            addonBefore={<SlCompass />}
-            placeholder={Strings.companyAddress}
-          />
-        </Form.Item>
+        <div className="flex">
+          <Form.Item
+            name="address"
+            className="flex-1"
+            rules={[
+              { required: true, message: Strings.requiredAddress },
+              { max: 200 },
+            ]}
+          >
+            <Input
+              size="large"
+              addonBefore={<SlCompass />}
+              placeholder={Strings.companyAddress}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteAddressTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
         <div className="flex flex-row flex-wrap">
           <Form.Item
             name="contact"
@@ -245,6 +274,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.contact}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteContactTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="position"
             rules={[
@@ -260,8 +292,11 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.position}
             />
           </Form.Item>
+          <Tooltip title={Strings.sitePositionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <div className="flex justify-between flex-row flex-wrap">
+        <div className="flex justify-between flex-row ">
           <Form.Item
             name="phone"
             rules={[{ required: true, message: Strings.requiredPhone }]}
@@ -273,6 +308,10 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.phone}
             />
           </Form.Item>
+          <Tooltip title={Strings.sitePhoneTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item name="extension">
             <InputNumber
               size="large"
@@ -281,6 +320,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.extension}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteExtensionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="cellular"
             rules={[{ required: true, message: Strings.requiredCellular }]}
@@ -292,23 +334,32 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.cellular}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteCellularTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="email"
-          rules={[
-            { required: true, message: Strings.requiredEmail },
-            { type: "email", message: Strings.requiredValidEmailAddress },
-            { max: 60 },
-          ]}
-        >
-          <Input
-            size="large"
-            maxLength={60}
-            addonBefore={<MailOutlined />}
-            placeholder={Strings.email}
-          />
-        </Form.Item>
-        <div className="flex flex-row flex-wrap">
+        <div className="flex">
+          <Form.Item
+            name="email"
+            className="flex-1"
+            rules={[
+              { required: true, message: Strings.requiredEmail },
+              { type: "email", message: Strings.requiredValidEmailAddress },
+              { max: 60 },
+            ]}
+          >
+            <Input
+              size="large"
+              maxLength={60}
+              addonBefore={<MailOutlined />}
+              placeholder={Strings.email}
+            />
+          </Form.Item>
+          <Tooltip title={Strings.siteEmailTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+        <div className="flex flex-row">
           <Form.Item
             name="dueDate"
             rules={[{ required: true, message: Strings.requiredDueDate }]}
@@ -320,6 +371,9 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.dueDate}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteDueDateTooltip}>
+            <QuestionCircleOutlined className="ml-0.5  mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="monthlyPayment"
             rules={[
@@ -334,6 +388,10 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               addonBefore={<FiDollarSign />}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteMonthlyPaymentTooltip}>
+            <QuestionCircleOutlined className="ml-0.5 mb-6 mr-2 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="currency"
             rules={[{ required: true, message: Strings.requiredCurrency }]}
@@ -345,19 +403,30 @@ const UpdateSiteForm = ({ form }: FormProps) => {
               placeholder={Strings.currency}
             />
           </Form.Item>
+          <Tooltip title={Strings.siteCurrencyTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
-        <Form.Item
-          name="appHistoryDays"
-          rules={[{ required: true, message: Strings.requiredAppHistoryDays }]}
-        >
-          <InputNumber
-            size="large"
-            maxLength={3}
-            placeholder={Strings.appHistoryDays}
-            addonBefore={<LuHistory />}
-          />
-        </Form.Item>
-        <Form.Item name="logoURL" className="hidden">
+        <div className="flex">
+          <Form.Item
+            name="appHistoryDays"
+            rules={[
+              { required: true, message: Strings.requiredAppHistoryDays },
+            ]}
+          >
+            <InputNumber
+              size="large"
+              maxLength={3}
+              placeholder={Strings.appHistoryDays}
+              addonBefore={<LuHistory />}
+            />
+          </Form.Item>
+        <Tooltip title={Strings.appHistoryDaysTooltip}>
+          <QuestionCircleOutlined className="ml-3 mb-6 text-blue-500 text-sm cursor-pointer" />
+        </Tooltip>
+        </div>
+          <div className="flex">
+          <Form.Item name="logoURL" className="hidden">
           <Input />
         </Form.Item>
         <Form.Item
@@ -377,6 +446,10 @@ const UpdateSiteForm = ({ form }: FormProps) => {
             {uploadButton}
           </Upload>
         </Form.Item>
+        <Tooltip title={Strings.siteLogoTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+          </div>
         <Form.Item>
           {previewImage && (
             <Image
@@ -391,6 +464,7 @@ const UpdateSiteForm = ({ form }: FormProps) => {
             />
           )}
         </Form.Item>
+        
         <Form.Item name="status" className="hidden">
           <Input />
         </Form.Item>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -342,6 +342,9 @@ static siteLogoTooltip = "Upload the site's logo. Accepted formats: JPG, PNG.";
 static siteCodeTooltip = "Auto-generated site code.";
 static appHistoryDaysTooltip = "Enter the number of days the application's history will be retained.";
 
-
+// Tooltips for Priority Form
+static priorityCodeTooltip = "A unique alphanumeric code representing the priority (e.g., '7D' for seven days). Maximum 4 characters.";
+static priorityDescriptionTooltip = "A brief description of the priority. Use clear, concise language. Maximum 50 characters.";
+static priorityDaysNumberTooltip = "The number of days associated with this priority. Must be a positive number.";
 
 }

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -317,4 +317,31 @@ export default class Strings {
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+  // Create-update tooltips strings
+  // Form tooltips
+// Form tooltips based on SiteEntity
+static siteNameTooltip = "Enter the name of the site . Maximum length: 100 characters.";
+static siteRfcTooltip = "Enter the  RFC for the company associated with the site. It should be exactly 13 characters long for companies.";
+static siteBusinessNameTooltip = "Enter the legal business name of the site, as registered officially. Maximum length: 100 characters.";
+static siteTypeTooltip = "Specify the type of the site (e.g., office, warehouse, retail). Maximum length: 20 characters.";
+static siteLatitudeTooltip = "Enter the latitude coordinates of the site. Use a format with up to 11 characters, e.g., '19.432608'.";
+static siteLongitudeTooltip = "Enter the longitude coordinates of the site. Use a format with up to 11 characters, e.g., '-99.133209'.";
+static siteAddressTooltip = "Provide the complete physical address of the site, including street, city, and ZIP code. Maximum length: 200 characters.";
+static siteContactTooltip = "Enter the name of the primary contact person for this site. Maximum length: 100 characters.";
+static sitePositionTooltip = "Specify the position or job title of the contact person (e.g., Manager, Supervisor). Maximum length: 100 characters.";
+static sitePhoneTooltip = "Provide the main contact phone number, including area code. Maximum length: 13 characters.";
+static siteExtensionTooltip = "If applicable, specify the phone extension for the contact person. Maximum length: 10 characters.";
+static siteCellularTooltip = "Provide a mobile phone number for the contact person. Maximum length: 13 characters.";
+static siteEmailTooltip = "Provide the email address of the contact person. Ensure it is valid and has a maximum length of 60 characters.";
+static siteDueDateTooltip = "Select the due date for site-related payments or obligations. Format: YYYY-MM-DD.";
+static siteMonthlyPaymentTooltip = "Specify the monthly payment amount for the site in decimal format, e.g., '1200.00'.";
+static siteCurrencyTooltip = "Select the currency for financial transactions related to this site. Use ISO 4217 codes (e.g., USD, MXN).";
+static siteAppHistoryDaysTooltip = "Enter the number of days to retain the site's application history. ";
+static siteLogoTooltip = "Upload the site's logo. Accepted formats: JPG, PNG.";
+static siteCodeTooltip = "Auto-generated site code.";
+static appHistoryDaysTooltip = "Enter the number of days the application's history will be retained.";
+
+
+
 }


### PR DESCRIPTION
### Feature / Bug Description
Add tooltips to the Create Update Site forms
### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design
### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-8)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/5d319d3d-3534-42f2-bfbf-1a8bb8c05895)
![image](https://github.com/user-attachments/assets/84e6e989-f9a1-4dc2-8020-dcc5013f0c34)

