### PR TITLE
KAN - 14 Add tooltips to the Create-Update Preclassifier tooltips

### DIFF
--- a/src/pages/preclassifier/components/RegisterPreclassifierForm.tsx
+++ b/src/pages/preclassifier/components/RegisterPreclassifierForm.tsx
@@ -1,7 +1,8 @@
-import { Form, FormInstance, Input } from "antd";
+import { Form, FormInstance, Input, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -25,6 +26,9 @@ const RegisterPreclassifierForm = ({ form }: FormProps) => {
               placeholder={Strings.code}
             />
           </Form.Item>
+          <Tooltip title={Strings.preclassifierCodeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
           <Form.Item
             name="description"
             validateFirst
@@ -38,6 +42,9 @@ const RegisterPreclassifierForm = ({ form }: FormProps) => {
               placeholder={Strings.description}
             />
           </Form.Item>
+          <Tooltip title={Strings.preclassifierDescriptionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-1.5 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
       </div>
     </Form>

--- a/src/pages/preclassifier/components/UpdatePreclassifierForm.tsx
+++ b/src/pages/preclassifier/components/UpdatePreclassifierForm.tsx
@@ -1,4 +1,4 @@
-import { Form, FormInstance, Input, Select } from "antd";
+import { Form, FormInstance, Input, Select, Tooltip } from "antd";
 import Strings from "../../../utils/localizations/Strings";
 import { BsCardText } from "react-icons/bs";
 import { CiBarcode } from "react-icons/ci";
@@ -8,6 +8,7 @@ import { selectCurrentRowData } from "../../../core/genericReducer";
 import { useGetStatusMutation } from "../../../services/statusService";
 import { Status } from "../../../data/status/status";
 import Preclassifier from "../../../data/preclassifier/preclassifier";
+import { QuestionCircleOutlined } from "@ant-design/icons";
 
 interface FormProps {
   form: FormInstance;
@@ -43,7 +44,7 @@ const UpdatePreclassifierForm = ({ form }: FormProps) => {
   return (
     <Form form={form}>
       <div className="flex flex-col">
-        <div className="flex flex-row justify-between flex-wrap">
+        <div className="flex flex-row justify-between ">
           <Form.Item name="id" className="hidden">
             <Input />
           </Form.Item>
@@ -59,6 +60,10 @@ const UpdatePreclassifierForm = ({ form }: FormProps) => {
               placeholder={Strings.code}
             />
           </Form.Item>
+          <Tooltip title={Strings.preclassifierCodeTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-1.5 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item
             name="description"
             validateFirst
@@ -71,13 +76,19 @@ const UpdatePreclassifierForm = ({ form }: FormProps) => {
               placeholder={Strings.description}
             />
           </Form.Item>
+          <Tooltip title={Strings.preclassifierDescriptionTooltip}>
+            <QuestionCircleOutlined className="ml-2 mr-1.5 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
+
           <Form.Item name="status" className="w-60">
             <Select size="large" options={statusOptions()} />
           </Form.Item>
+          <Tooltip title={Strings.preclassifierStatusTooltip}>
+            <QuestionCircleOutlined className="ml-2 mb-6 text-blue-500 text-sm cursor-pointer" />
+          </Tooltip>
         </div>
       </div>
     </Form>
   );
 };
-
 export default UpdatePreclassifierForm;

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -306,15 +306,20 @@ export default class Strings {
   static colon = ":";
 
   static downloadData = "Download data";
-   //Rangepricker presets
-   static last7days = "Last 7 Days";
-   static last14days = "Last 14 Days";
-   static last30days = "Last 30 Days";
-   static last90days = "Last 90 Days";
- 
-   static failedToDownload = "Failed to download";
+  //Rangepricker presets
+  static last7days = "Last 7 Days";
+  static last14days = "Last 14 Days";
+  static last30days = "Last 30 Days";
+  static last90days = "Last 90 Days";
+
+  static failedToDownload = "Failed to download";
 
   //warning notifications
   static restrictedAccessMessage =
     "Access Denied: Your role is limited to the app and does not grant permission to access the site. Please contact the administrator if you believe this is an error.";
+
+  // Create Update preclassifier tooltips
+  static preclassifierCodeTooltip = "Enter the preclassifier code.";
+  static preclassifierDescriptionTooltip = "Provide a detailed description for the preclassifier. Maximum length: 100 characters.";
+  static preclassifierStatusTooltip = "Select the status of the preclassifier.";
 }


### PR DESCRIPTION
### Feature / Bug Description
-  Add tooltips to the Create-Update Preclassifier tooltips

### Solution
- Use the [Tooltip component](https://ant.design/components/tooltip) from Ant Design

### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-14)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/509a046a-463b-4dd5-93c3-e078ebb6781c)
![image](https://github.com/user-attachments/assets/62b19763-38cc-4b38-b9e5-b206880cb4f8)

