### PR TITLE
KAN - 34 Update status in the update user modal

### DIFF
--- a/src/pages/user/components/UpdateSiteUserForm.tsx
+++ b/src/pages/user/components/UpdateSiteUserForm.tsx
@@ -39,6 +39,11 @@ const UpdateSiteUserForm = ({ form }: FormProps) => {
 
   const filteredOptions = roles.filter((o) => !selectedRoles.includes(o));
 
+  const statusOptions = [
+    { value: "A", label: Strings.active },
+    { value: "I", label: Strings.inactive },
+  ];
+
   return (
     <Form form={form} layout="vertical">
       <div className="flex flex-col">
@@ -108,7 +113,9 @@ const UpdateSiteUserForm = ({ form }: FormProps) => {
               ({ getFieldValue }) => ({
                 validator(_, value) {
                   if (!value && getFieldValue("password")) {
-                    return Promise.reject(new Error(Strings.requiredPassword));
+                    return Promise.reject(
+                      new Error(Strings.requiredPassword)
+                    );
                   }
                   if (value && getFieldValue("password") !== value) {
                     return Promise.reject(
@@ -166,8 +173,17 @@ const UpdateSiteUserForm = ({ form }: FormProps) => {
             }))}
           />
         </Form.Item>
-        <Form.Item className="hidden" name="status">
-          <Input />
+        <Form.Item
+          name="status"
+          validateFirst
+          rules={[{ required: true, message: Strings.requiredStatus }]}
+          className="w-60"
+        >
+          <Select
+            size="large"
+            placeholder={Strings.statusPlaceholder}
+            options={statusOptions}
+          />
         </Form.Item>
       </div>
     </Form>

--- a/src/pages/user/components/UpdateUserForm.tsx
+++ b/src/pages/user/components/UpdateUserForm.tsx
@@ -67,6 +67,11 @@ const UpdateUserForm = ({ form }: FormProps) => {
 
   const filteredOptions = roles.filter((o) => !selectedRoles.includes(o));
 
+  const statusOptions = [
+    { value: Strings.activeValue, label: Strings.active },
+    { value: Strings.inactiveValue, label: Strings.inactive },
+  ];
+
   return (
     <Form form={form} layout="vertical">
       <div className="flex flex-col">
@@ -226,8 +231,18 @@ const UpdateUserForm = ({ form }: FormProps) => {
             }))}
           />
         </Form.Item>
-        <Form.Item className="hidden" name="status">
-          <Input />
+        <Form.Item
+          name="status"
+          label = {Strings.statusUserLabel}
+          validateFirst
+          rules={[{ required: true, message: Strings.requiredStatus }]}
+          className="w-60"
+        >
+          <Select
+            size="large"
+            placeholder={Strings.statusPlaceholder}
+            options={statusOptions}
+          />
         </Form.Item>
       </div>
     </Form>

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -326,5 +326,7 @@ export default class Strings {
   // User status
     static requiredStatus= "Status is required"
     static statusPlaceholder = "Choose a status"
-
+    static activeValue = "A"
+    static inactiveValue = "I"
+    static statusUserLabel = "User status"
 }

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -323,5 +323,8 @@ export default class Strings {
     static priorityDescriptionTooltip = "A brief description of the priority. Use clear, concise language. Maximum 50 characters.";
     static priorityDaysNumberTooltip = "The number of days associated with this priority. Must be a positive number.";
 
-  
+  // User status
+    static requiredStatus= "Status is required"
+    static statusPlaceholder = "Choose a status"
+
 }


### PR DESCRIPTION
### Feature / Bug Description
Update status in the update user modal

### Solution
Put a select instead the hidden input releated with the status field
### Notes
- I had to add a line to the user service to ensure the status was updated correctly during user updates.

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-34)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/1c0318bb-3283-487d-8476-5cbe1ee8aae3)

