### PR TITLE
KAN - 60 Refactor levels tree 2

### DIFF
--- a/src/pages/level/Levels.tsx
+++ b/src/pages/level/Levels.tsx
@@ -134,7 +134,14 @@ const Levels = ({}: Props) => {
     }
   };
 
+  const closeAllDrawers = () => {
+    setDetailsVisible(false);
+    setDrawerVisible(false);
+  };
+  
+
   const handleCreateLevel = () => {
+    closeAllDrawers();
     const supId = selectedNode?.data?.id;
 
     if (supId === "0") {
@@ -151,6 +158,7 @@ const Levels = ({}: Props) => {
   };
 
   const handleUpdateLevel = () => {
+    closeAllDrawers();
     setDrawerType("update");
     updateForm.resetFields();
 
@@ -163,6 +171,7 @@ const Levels = ({}: Props) => {
   };
 
   const handleCloneLevel = () => {
+    closeAllDrawers();
     setDrawerType("clone");
     createForm.resetFields();
 
@@ -246,6 +255,7 @@ const Levels = ({}: Props) => {
 
     const handleShowDetails = (nodeId: string) => {
       if (nodeId !== "0") {
+        closeAllDrawers();
         setSelectedLevelId(nodeId);
         setDetailsVisible(true);
         setContextMenuVisible(false);
@@ -359,7 +369,15 @@ const Levels = ({}: Props) => {
 
       {detailsVisible && selectedLevelId && (
         <Drawer
-          title={Strings.levelDetailsTitle}
+          mask={false} 
+          maskClosable={false} 
+          title={
+            Strings.levelDetailsTitle.concat(
+              selectedNode?.data?.name
+                ? `: ${selectedNode.data.name}`
+                : ""
+            )
+          }
           placement={drawerPlacement}
           height={drawerPlacement === "bottom" ? "50vh" : undefined}
           width={drawerPlacement === "right" ? 400 : undefined}
@@ -377,15 +395,27 @@ const Levels = ({}: Props) => {
       )}
 
       <Drawer
-        title={
-          drawerType === Strings.drawerTypeCreate
-            ? Strings.levelsTreeOptionCreate.concat(" " + Strings.level)
-            : drawerType === Strings.drawerTypeEdit
-            ? Strings.levelsTreeOptionEdit.concat(" " + Strings.level)
-            : drawerType === Strings.drawerTypeClone
-            ? Strings.levelsTreeOptionClone.concat(" " + Strings.level)
-            : ""
-        }
+ title={
+  drawerType === Strings.drawerTypeCreate
+    ? Strings.levelsTreeOptionCreate.concat(
+        selectedNode?.data?.name
+          ? ` ${Strings.for} "${selectedNode.data.name}"`
+          : Strings.empty
+      )
+    : drawerType === Strings.drawerTypeEdit
+    ? Strings.levelsTreeOptionEdit.concat(
+        selectedNode?.data?.name
+          ? ` "${selectedNode.data.name}" ${Strings.level}`
+          : Strings.empty
+      )
+    : drawerType === Strings.drawerTypeClone
+    ? Strings.levelsTreeOptionClone.concat(
+        selectedNode?.data?.name
+          ? ` "${selectedNode.data.name}" ${Strings.level}`
+          : Strings.empty
+      )
+    : Strings.empty
+}
         placement={drawerPlacement}
         height={drawerPlacement === "bottom" ? "50vh" : undefined}
         width={drawerPlacement === "right" ? 400 : undefined}
@@ -394,6 +424,8 @@ const Levels = ({}: Props) => {
         destroyOnClose
         closable={true}
         className="drawer-responsive"
+        mask={false} 
+        maskClosable={false} 
       >
         <Form.Provider
           onFormFinish={async (_name, { values }) => {

--- a/src/pages/level/components/LevelDetails.tsx
+++ b/src/pages/level/components/LevelDetails.tsx
@@ -8,10 +8,10 @@ const { Title } = Typography;
 
 interface LevelDetailsProps {
   levelId: string;
-  onClose: () => void; // Function to close the panel
+  onClose: () => void;
 }
 
-const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId, onClose }) => {
+const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId }) => {
   const [getLevel] = useGetlevelMutation();
   const [levelData, setLevelData] = useState<Level | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -22,7 +22,7 @@ const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId, onClose }) => {
         const response = await getLevel(levelId).unwrap();
         setLevelData(response);
       } catch (error) {
-        console.error("Error fetching level data:", error);
+        console.error(Strings.errorFetchingLevelData);
       } finally {
         setIsLoading(false);
       }
@@ -35,8 +35,8 @@ const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId, onClose }) => {
     switch (status) {
       case Strings.detailsOptionA:
         return Strings.detailsStatusActive;
-        case Strings.detailsOptionC:
-        return Strings.detailsStatsCancelled;
+      case Strings.detailsOptionC:
+        return Strings.detailsStatusCancelled;
       case Strings.detailsOptionS:
         return Strings.detailsStatusSuspended;
       default:
@@ -45,16 +45,16 @@ const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId, onClose }) => {
   };
 
   if (isLoading) {
-    return <Spin tip={"Loading"} className="flex justify-center mt-10" />;
+    return <Spin tip={Strings.loading} className="flex justify-center mt-10" />;
   }
 
   if (!levelData) {
-    return <div className="text-center">{"No data"}</div>;
+    return <div className="text-center">{Strings.noData}</div>;
   }
 
   return (
-    <div className="mt-10 p-4 bg-white shadow-md rounded-md border border-gray-300">
-      <Title level={4}>{"Level Details"}</Title>
+    <div className="p-4 bg-white shadow-md rounded-md border border-gray-300">
+      <Title level={4}>{Strings.levelDetailsTitle}</Title>
       <Descriptions bordered column={1}>
         <Descriptions.Item label={Strings.name}>
           {levelData.name}
@@ -69,20 +69,12 @@ const LevelDetails: React.FC<LevelDetailsProps> = ({ levelId, onClose }) => {
           {getStatusText(levelData.status)}
         </Descriptions.Item>
         <Descriptions.Item label={Strings.notify}>
-          {levelData.notify ? "Yes" : "No"}
+          {levelData.notify ? Strings.yes : Strings.no}
         </Descriptions.Item>
         <Descriptions.Item label={Strings.levelMachineId}>
           {levelData.levelMachineId || Strings.none}
         </Descriptions.Item>
       </Descriptions>
-      <div className="flex justify-end mt-4">
-        <button
-          onClick={onClose}
-          className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700"
-        >
-          {Strings.close}
-        </button>
-      </div>
     </div>
   );
 };

--- a/src/pages/level/components/RegisterLevelForm.tsx
+++ b/src/pages/level/components/RegisterLevelForm.tsx
@@ -22,6 +22,7 @@ const RegisterLevelForm = ({ form }: FormProps) => {
     const responsibles = await getResponsibles(siteId).unwrap();
     setData(responsibles);
   };
+
   useEffect(() => {
     handleGetResponsibles();
   }, []);
@@ -32,70 +33,82 @@ const RegisterLevelForm = ({ form }: FormProps) => {
       label: responsible.name,
     }));
   };
+
   return (
-    <Form form={form} layout="vertical">
-      <div className="flex flex-col">
-        <div className="flex flex-row flex-wrap">
-          <Form.Item
-            name="name"
-            validateFirst
-            rules={[{ required: true, message: Strings.name }, { max: 45 }]}
-            className="mr-1"
-          >
-            <Input
-              size="large"
-              maxLength={45}
-              addonBefore={<LuTextCursor />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="description"
-            validateFirst
-            rules={[
-              { required: true, message: Strings.requiredDescription },
-              { max: 100 },
-            ]}
-            className="md:flex-1 w-2/3"
-          >
-            <Input
-              size="large"
-              maxLength={100}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
-          </Form.Item>
-        </div>
-        <div className="flex flex-wrap gap-1">
-          <Form.Item name="responsibleId" className="flex-1">
-            <Select
-              size="large"
-              placeholder={Strings.responsible}
-              options={selectOptions()}
-              showSearch
-              filterOption={(input, option) => {
-                if (!option) {
-                  return false;
-                }
-                return option.label.toLowerCase().includes(input.toLowerCase());
-              }}
-            />
-          </Form.Item>
-          <Form.Item name="levelMachineId" className="md:flex-1">
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.levelMachineId}
-            />
-          </Form.Item>
-        </div>
-        <Form.Item name="notify" valuePropName="checked">
-          <Checkbox>
-            <p className="text-base">{Strings.notify}</p>
-          </Checkbox>
-        </Form.Item>
-      </div>
+    <Form
+      form={form}
+      layout="vertical"
+      className="flex flex-col gap-1 w-full"
+    >
+      <Form.Item
+        name="name"
+        validateFirst
+        rules={[
+          { required: true, message: Strings.name },
+          
+        ]}
+      >
+        <Input
+          size="large"
+          maxLength={45}
+          addonBefore={<LuTextCursor />}
+          placeholder={Strings.name}
+        />
+      </Form.Item>
+
+      <Form.Item
+        name="description"
+        validateFirst
+        rules={[
+          { required: true, message: Strings.requiredDescription },
+          
+        ]}
+      >
+        <Input
+          size="large"
+          maxLength={100}
+          addonBefore={<BsCardText />}
+          placeholder={Strings.description}
+        />
+      </Form.Item>
+
+      <Form.Item
+  name="responsibleId"
+  rules={[{ required: true, message: Strings.responsibleRequired }]}>
+  <Select
+    size="large"
+    placeholder={Strings.responsible}
+    options={selectOptions()}
+    showSearch
+    filterOption={(input, option) => {
+      if (!option) {
+        return false;
+      }
+      return option.label.toLowerCase().includes(input.toLowerCase());
+    }}
+  />
+</Form.Item>
+
+
+      <Form.Item name="levelMachineId">
+        <Input
+          size="large"
+          maxLength={50}
+          addonBefore={<CiBarcode />}
+          placeholder={Strings.levelMachineId}
+        />
+      </Form.Item>
+
+      <Form.Item name="notify" valuePropName="checked">
+        <Checkbox>
+          <p className="text-base">{Strings.notify}</p>
+        </Checkbox>
+      </Form.Item>
+
+      {/* Campo oculto */}
+      <Form.Item name="superiorId" hidden>
+        <Input type="hidden" />
+      </Form.Item>
     </Form>
   );
 };

--- a/src/pages/level/components/UpdateLevelForm.tsx
+++ b/src/pages/level/components/UpdateLevelForm.tsx
@@ -36,7 +36,7 @@ const UpdateLevelForm = ({ form, initialValues }: FormProps) => {
     handleGetData();
     const defaultValues = {
       ...initialValues,
-      notify: initialValues?.notify !== undefined ? Number(initialValues.notify) : 0, // Convertir a número
+      notify: initialValues?.notify !== undefined ? Number(initialValues.notify) : 0,
     };
 
     if (defaultValues) {
@@ -62,63 +62,64 @@ const UpdateLevelForm = ({ form, initialValues }: FormProps) => {
 
   return (
     <Form form={form} layout="vertical">
-      <div className="flex flex-col">
-        <div className="flex flex-row flex-wrap">
-          <Form.Item name="id" className="hidden">
-            <Input />
-          </Form.Item>
-          <Form.Item
-            name="name"
-            rules={[{ required: true, message: Strings.name }, { max: 45 }]}
-            className="mr-1"
-          >
-            <Input
-              size="large"
-              maxLength={45}
-              addonBefore={<LuTextCursor />}
-              placeholder={Strings.name}
-            />
-          </Form.Item>
-          <Form.Item
-            name="description"
-            rules={[{ required: true, message: Strings.requiredDescription }, { max: 100 }]}
-            className="md:flex-1 w-2/3"
-          >
-            <Input
-              size="large"
-              maxLength={100}
-              addonBefore={<BsCardText />}
-              placeholder={Strings.description}
-            />
-          </Form.Item>
-        </div>
-        <div className="flex gap-1 flex-wrap">
-          <Form.Item name="responsibleId" className="flex-1">
-            <Select
-              size="large"
-              placeholder={Strings.responsible}
-              options={responsibleOptions()}
-            />
-          </Form.Item>
-          <Form.Item name="levelMachineId" className="md:flex-1 w-2/3">
-            <Input
-              size="large"
-              maxLength={50}
-              addonBefore={<CiBarcode />}
-              placeholder={Strings.levelMachineId}
-            />
-          </Form.Item>
-        </div>
-        <div className="flex gap-3">
-          <Form.Item name="status" className="w-60">
-            <Select size="large" options={statusOptions()} />
-          </Form.Item>
-          <Form.Item name="notify" valuePropName="checked">
-            <Checkbox>
-              <p className="text-base">{Strings.notify}</p>
-            </Checkbox>
-          </Form.Item>
-        </div>
+      <div className="flex flex-col gap-1">
+        <Form.Item name="id" className="hidden">
+          <Input />
+        </Form.Item>
+
+        <Form.Item
+          name="name"
+          rules={[{ required: true, message: Strings.name }, { max: 45 }]}
+        >
+          <Input
+            size="large"
+            maxLength={45}
+            addonBefore={<LuTextCursor />}
+            placeholder={Strings.name}
+          />
+        </Form.Item>
+
+        <Form.Item
+          name="description"
+          rules={[
+            { required: true, message: Strings.requiredDescription },
+            { max: 100 },
+          ]}
+        >
+          <Input
+            size="large"
+            maxLength={100}
+            addonBefore={<BsCardText />}
+            placeholder={Strings.description}
+          />
+        </Form.Item>
+
+        <Form.Item name="responsibleId">
+          <Select
+            size="large"
+            placeholder={Strings.responsible}
+            options={responsibleOptions()}
+          />
+        </Form.Item>
+
+        <Form.Item name="levelMachineId">
+          <Input
+            size="large"
+            maxLength={50}
+            addonBefore={<CiBarcode />}
+            placeholder={Strings.levelMachineId}
+          />
+        </Form.Item>
+
+        <Form.Item name="status">
+          <Select size="large" placeholder={Strings.status} options={statusOptions()} />
+        </Form.Item>
+
+        <Form.Item name="notify" valuePropName="checked">
+          <Checkbox>
+            <p className="text-base">{Strings.notify}</p>
+          </Checkbox>
+        </Form.Item>
       </div>
     </Form>
   );

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -484,6 +484,7 @@ static companyLogoTooltip = "Upload the company logo in image format.";
     static yes = "Yes";
     static no = "No";
     static detailsStatusCancelled = "Cancelled";
-
+    static for = "for"
+    
 
 }

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -244,7 +244,7 @@ export default class Strings {
   //Tags re-design
   static tagsOf = "Tags of";
   static filters = "Filters";
-  static status = "Status: ";
+  static status = "Status ";
   static dueDate = "Due date: ";
   static cardType = "Tag type: ";
   static problemType = "Problem type: ";
@@ -342,7 +342,7 @@ export default class Strings {
     static updateLevelTree = "Update Level";
     static details = "Details";
     static levelsOf = "Levels of ";
-    static newLevel = "New Level";
+    static newLevel = " New Level";
     static level = "Level";
     static errorFetchingLevels = "Error fetching levels";
     static errorSavingLevel = "Error saving level";
@@ -465,5 +465,25 @@ static companyLogoTooltip = "Upload the company logo in image format.";
     static notificationsSave = "Save";
     static notificationsCancel = "Cancel";
     static searchUsers = "Search User"
+
+    
+    static responsibleRequired = "Responsible Required"
+    static levelsTreeOptionCreate = "Create";
+    static levelsTreeOptionClose = "Close";
+    static levelsTreeOptionEdit = "Edit";
+    static levelsTreeOptionClone = "Clone";
+    static levelDetailsTitle = "Level Details";
+    static errorOnSubmit = "Error on submit";
+    static drawerTypeCreate = "create"
+    static drawerTypeEdit = "update"
+    static drawerTypeClone = "clone"
+    
+    static loading = "Loading";
+    static noData = "No data";
+    static errorFetchingLevelData = "Error fetching level data";
+    static yes = "Yes";
+    static no = "No";
+    static detailsStatusCancelled = "Cancelled";
+
 
 }


### PR DESCRIPTION
### Feature / Bug Description
- Refactor Levels Tree
### Solution
- The Levels Tree section was reorganized, the forms were placed in Ant Design drawers, the registration component was reused for the clone option, node colors were updated, and responsiveness was adjusted.

### Notes
- n/a 

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-60)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/cbf103c5-e9cf-40cc-b3e8-db2f7cc26c55)
![image](https://github.com/user-attachments/assets/1f87158f-128f-4e26-ab34-1677531b6fbb)

