### PR TITLE
KAN - 43 Refactor Card Types and Preclassifier tree

### DIFF
--- a/src/pages/cardtypes/CardTypes.tsx
+++ b/src/pages/cardtypes/CardTypes.tsx
@@ -1,206 +1,677 @@
-import { useEffect, useState } from "react";
-import { Form, Input, List, Space } from "antd";
-import { IoIosSearch } from "react-icons/io";
-import Strings from "../../utils/localizations/Strings";
-import CustomButton from "../../components/CustomButtons";
+import { Drawer, Dropdown, Form, Spin } from "antd";
+import { useEffect, useRef, useState } from "react";
+import Tree from "react-d3-tree";
 import { useLocation, useNavigate } from "react-router-dom";
-import CardTypesTable from "./components/CardTypesTable";
-import { CardTypes } from "../../data/cardtypes/cardTypes";
-import PaginatedList from "../../components/PaginatedList";
-import CardTypesCard from "./components/CardTypesCard";
-import ModalForm from "../../components/ModalForm";
+import Strings from "../../utils/localizations/Strings";
 import RegisterCardTypeForm from "./components/RegisterCardTypeForm";
-import { CreateCardType } from "../../data/cardtypes/cardTypes.request";
+import UpdateCardTypeForm from "./components/UpdateCardTypeForm";
+import RegisterPreclassifierForm2 from "./components/preclassifier/RegisterPreclassifierForm";
+import UpdatePreclassifierForm2 from "./components/preclassifier/UpdatePreclassifierForm";
 import {
   NotificationSuccess,
   handleErrorNotification,
   handleSucccessNotification,
 } from "../../utils/Notifications";
 import {
-  resetCardTypeUpdatedIndicator,
-  selectCardTypeUpdatedIndicator,
-  setSiteId,
-} from "../../core/genericReducer";
-import { useAppDispatch, useAppSelector } from "../../core/store";
-import PageTitle from "../../components/PageTitle";
+  useCreateCardTypeMutation,
+  useGetCardTypesMutation,
+  useUpdateCardTypeMutation,
+} from "../../services/CardTypesService";
+import {
+  useCreatePreclassifierMutation,
+  useGetPreclassifiersMutation,
+  useUpdatePreclassifierMutation,
+} from "../../services/preclassifierService";
+import { setSiteId } from "../../core/genericReducer";
+import { useAppDispatch } from "../../core/store";
+import { CardTypes } from "../../data/cardtypes/cardTypes";
+import {
+  CreateCardType,
+  UpdateCardTypeReq,
+} from "../../data/cardtypes/cardTypes.request";
+import { CreatePreclassifier } from "../../data/preclassifier/preclassifier.request";
 import { UserRoles } from "../../utils/Extensions";
-import { UnauthorizedRoute } from "../../utils/Routes";
-import { useCreateCardTypeMutation, useGetCardTypesMutation } from "../../services/CardTypesService";
+import CardTypeDetails from "./components/CardTypeDetails";
+import PreclassifierDetails from "./components/preclassifier/PreclassifierDetails";
 
-interface CardTypeProps {
+function useMediaQuery(query: string) {
+  const [matches, setMatches] = useState<boolean>(false);
+
+  useEffect(() => {
+    const media = window.matchMedia(query);
+    if (media.matches !== matches) {
+      setMatches(media.matches);
+    }
+    const listener = () => setMatches(media.matches);
+    media.addEventListener("change", listener);
+    return () => media.removeEventListener("change", listener);
+  }, [matches, query]);
+
+  return matches;
+}
+
+interface LocationState {
+  siteId: string;
+  siteName: string;
+}
+
+type DrawerType =
+  | typeof Strings.cardTypesDrawerTypeCreateCardType
+  | typeof Strings.cardTypesDrawerTypeUpdateCardType
+  | typeof Strings.cardTypesDrawerTypeCreatePreclassifier
+  | typeof Strings.cardTypesDrawerTypeUpdatePreclassifier
+  | null;
+
+const buildHierarchy = (
+  data: CardTypes[],
+  siteId: string,
+  preclassifiersMap: { [cardTypeId: string]: any[] }
+) => {
+  const map: { [key: string]: any } = {};
+  const tree: any[] = [];
+
+  data.forEach((node) => {
+    map[node.id] = {
+      ...node,
+      name: node.name,
+      nodeType: "cardType",
+      children: [],
+    };
+    const preclassifiers = preclassifiersMap[node.id] || [];
+    if (preclassifiers.length > 0) {
+      map[node.id].children = preclassifiers.map((pc) => ({
+        ...pc,
+        name: pc.preclassifierDescription,
+        nodeType: "preclassifier",
+        cardTypeId: pc.cardTypeId,
+        children: [],
+      }));
+    }
+  });
+
+  data.forEach((node) => {
+    if (`${node.siteId}` === `${siteId}`) {
+      tree.push(map[node.id]);
+    } else if (map[node.siteId]) {
+      map[node.siteId].children.push(map[node.id]);
+    }
+  });
+
+  return tree;
+};
+
+interface CardTypesTreeProps {
   rol: UserRoles;
 }
 
-const CardTypess = ({ rol }: CardTypeProps) => {
+const CardTypesTree = ({ rol }: CardTypesTreeProps) => {
   const [getCardTypes] = useGetCardTypesMutation();
-  const [isLoading, setLoading] = useState(false);
-  const location = useLocation();
-  const [data, setData] = useState<CardTypes[]>([]);
-  const [querySearch, setQuerySearch] = useState(Strings.empty);
-  const [dataBackup, setDataBackup] = useState<CardTypes[]>([]);
-  const [modalIsOpen, setModalOpen] = useState(false);
-  const [registerCardType] = useCreateCardTypeMutation();
-  const [modalIsLoading, setModalLoading] = useState(false);
-  const dispatch = useAppDispatch();
-  const isCardTypeUpdated = useAppSelector(selectCardTypeUpdatedIndicator);
+  const [createCardType] = useCreateCardTypeMutation();
+  const [updateCardType] = useUpdateCardTypeMutation();
+  const [getPreclassifiers] = useGetPreclassifiersMutation();
+  const [createPreclassifier] = useCreatePreclassifierMutation();
+  const [updatePreclassifier] = useUpdatePreclassifierMutation();
+
+  const [treeData, setTreeData] = useState<any[]>([]);
+  const [selectedNode, setSelectedNode] = useState<any>(null);
+  const [drawerVisible, setDrawerVisible] = useState(false);
+  const [drawerType, setDrawerType] = useState<DrawerType>(null);
+  const [formData, setFormData] = useState<any>(null);
+
+  const [detailsVisible, setDetailsVisible] = useState(false);
+  const [detailsNode, setDetailsNode] = useState<any>(null);
+
+  const [createForm] = Form.useForm();
+  const [updateForm] = Form.useForm();
+  const [createPreForm] = Form.useForm();
+  const [updatePreForm] = Form.useForm();
+
+  const [loading, setLoading] = useState(false);
+
+  const location = useLocation() as unknown as Location & {
+    state: LocationState;
+  };
   const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [translate, setTranslate] = useState({ x: 0, y: 0 });
+
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
+  const stripCloneSuffix = (original: string) => {
+    return original.replace(/\(Clone.*\)$/i, Strings.empty).trim();
+  };
+
+  const formatColor = (colorValue: any) => {
+    if (!colorValue) return "transparent";
+    let c =
+      typeof colorValue === "string"
+        ? colorValue
+        : colorValue?.toHex?.() || Strings.empty;
+    return c.startsWith("#") ? c.slice(1) : c;
+  };
 
   useEffect(() => {
-    if (isCardTypeUpdated) {
-      handleGetPriorities();
-      dispatch(resetCardTypeUpdatedIndicator());
-    }
-  }, [isCardTypeUpdated, dispatch]);
-
-  const handleOnClickCreateButton = () => {
-    setModalOpen(true);
-  };
-  const handleOnCancelButton = () => {
-    if (!modalIsLoading) {
-      setModalOpen(false);
-    }
-  };
-
-  const handleOnSearch = (event: any) => {
-    const getSearch = event.target.value;
-
-    if (getSearch.length > 0) {
-      const filterData = dataBackup.filter((item) => search(item, getSearch));
-
-      setData(filterData);
+    if (location?.state?.siteId) {
+      handleLoadData(location.state.siteId);
     } else {
-      setData(dataBackup);
+      navigate("/unauthorized");
     }
-    setQuerySearch(getSearch);
-  };
-
-  const search = (item: CardTypes, search: string) => {
-    const { name, methodology } = item;
-
-    return (
-      name.toLowerCase().includes(search.toLowerCase()) ||
-      methodology.toLowerCase().includes(search.toLowerCase())
-    );
-  };
-
-  const handleGetPriorities = async () => {
-    if (!location.state) {
-      navigate(UnauthorizedRoute);
-      return;
-    }
-    setLoading(true);
-    const response = await getCardTypes(location.state.siteId).unwrap();
-    setData(response);
-    setDataBackup(response);
-    dispatch(setSiteId(location.state.siteId));
-    setLoading(false);
-  };
-
-  useEffect(() => {
-    handleGetPriorities();
   }, [location.state]);
 
-  const handleOnFormCreateFinish = async (values: any) => {
+  const handleLoadData = async (siteId: string) => {
+    setLoading(true);
     try {
-      setModalLoading(true);
-      const aux = values.cardTypeMethodology.split(" - ");
-      const cardTypeMethodology = aux[1];
-      const methodologyName = aux[0];
-      await registerCardType(
-        new CreateCardType(
+      const cardTypesResponse = await getCardTypes(siteId).unwrap();
+
+      const promises = cardTypesResponse.map(async (ct) => {
+        const preclassResp = await getPreclassifiers(String(ct.id)).unwrap();
+        return { cardTypeId: ct.id, preclassifiers: preclassResp };
+      });
+
+      const results = await Promise.all(promises);
+      const preclassMap: { [key: string]: any[] } = {};
+
+      results.forEach((r) => {
+        preclassMap[r.cardTypeId] = r.preclassifiers;
+      });
+
+      const hierarchy = buildHierarchy(cardTypesResponse, siteId, preclassMap);
+      setTreeData([
+        {
+          name: `${Strings.cardType} ${location.state.siteName}`,
+          nodeType: "cardType",
+          children: hierarchy,
+        },
+      ]);
+
+      dispatch(setSiteId(siteId));
+
+      if (containerRef.current) {
+        const { offsetWidth, offsetHeight } = containerRef.current;
+        setTranslate({ x: offsetWidth / 2, y: offsetHeight / 4 });
+      }
+    } catch (err) {
+      console.error(Strings.cardTypesErrorFetchingData, err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDrawerClose = () => {
+    setDrawerVisible(false);
+    setDrawerType(null);
+    setFormData(null);
+    setSelectedNode(null);
+
+    createForm.resetFields();
+    updateForm.resetFields();
+    createPreForm.resetFields();
+    updatePreForm.resetFields();
+  };
+
+  const handleDrawerOpen = (type: DrawerType, data: any = null) => {
+    setDrawerType(type);
+    setDrawerVisible(true);
+    setSelectedNode(data || null);
+
+    let nextFormData: any = data || {};
+
+    if (type === Strings.cardTypesDrawerTypeCreateCardType && data) {
+      const baseName = stripCloneSuffix(data.name);
+      const formattedMethodology =
+        typeof data.cardTypeMethodology === "string"
+          ? data.cardTypeMethodology
+          : `${data.cardTypeMethodologyName || Strings.empty} - ${
+              data.cardTypeMethodology || Strings.empty
+            }`;
+
+      nextFormData = {
+        ...data,
+        cardTypeMethodology: formattedMethodology,
+        name: `${baseName} ${Strings.cardTypesCloneSuffix}`,
+      };
+    }
+
+    if (type === Strings.cardTypesDrawerTypeCreateCardType && !data) {
+      nextFormData = {};
+    }
+
+    if (type === Strings.cardTypesDrawerTypeCreatePreclassifier && data) {
+      if (data.preclassifierCode) {
+        const baseDesc = stripCloneSuffix(
+          data.preclassifierDescription || Strings.empty
+        );
+        nextFormData = {
+          ...data,
+          code: data.preclassifierCode,
+          description: `${baseDesc} ${Strings.cardTypesCloneSuffix}`,
+          cardTypeId: data.cardTypeId,
+        };
+      } else {
+        nextFormData = {
+          ...data,
+          code: Strings.empty,
+          description: Strings.empty,
+          cardTypeId: data.cardTypeId,
+        };
+      }
+    }
+
+    setFormData(nextFormData);
+  };
+
+  const handleOnFormFinish = async (values: any) => {
+    try {
+      setLoading(true);
+
+      if (drawerType === Strings.cardTypesDrawerTypeCreateCardType) {
+        if (!values.cardTypeMethodology) {
+          throw new Error(Strings.cardTypesMethodologyError);
+        }
+
+        const aux = values.cardTypeMethodology.split(" - ");
+        const cardTypeMethodology = aux[1];
+        const methodologyName = aux[0];
+
+        const newCardType = new CreateCardType(
           cardTypeMethodology,
           Number(location.state.siteId),
           methodologyName,
-          values.name.trim(),
-          values.description.trim(),
-          values.color.toHex(),
-          Number(values.responsableId),
-          Number(values.quantityPicturesCreate),
-          Number(values.quantityAudiosCreate),
-          Number(values.quantityVideosCreate),
-          Number(values.audiosDurationCreate),
-          Number(values.videosDurationCreate),
-          Number(values.quantityPicturesClose),
-          Number(values.quantityAudiosClose),
-          Number(values.quantityVideosClose),
-          Number(values.audiosDurationClose),
-          Number(values.videosDurationClose),
-          Number(values.quantityPicturesPs),
-          Number(values.quantityAudiosPs),
-          Number(values.quantityVideosPs),
-          Number(values.audiosDurationPs),
-          Number(values.videosDurationPs)
-        )
-      ).unwrap();
-      setModalOpen(false);
-      handleGetPriorities();
-      handleSucccessNotification(NotificationSuccess.REGISTER);
+          values.name?.trim() || Strings.empty,
+          values.description?.trim() || Strings.empty,
+          formatColor(values.color),
+          Number(values.responsableId || 0),
+          Number(values.quantityPicturesCreate || 0),
+          Number(values.quantityAudiosCreate || 0),
+          Number(values.quantityVideosCreate || 0),
+          Number(values.audiosDurationCreate || 0),
+          Number(values.videosDurationCreate || 0),
+          Number(values.quantityPicturesClose || 0),
+          Number(values.quantityAudiosClose || 0),
+          Number(values.quantityVideosClose || 0),
+          Number(values.audiosDurationClose || 0),
+          Number(values.videosDurationClose || 0),
+          Number(values.quantityPicturesPs || 0),
+          Number(values.quantityAudiosPs || 0),
+          Number(values.quantityVideosPs || 0),
+          Number(values.audiosDurationPs || 0),
+          Number(values.videosDurationPs || 0)
+        );
+        await createCardType(newCardType).unwrap();
+        handleSucccessNotification(NotificationSuccess.REGISTER);
+      } else if (
+        drawerType === Strings.cardTypesDrawerTypeUpdateCardType &&
+        selectedNode
+      ) {
+        const updatedCardType = new UpdateCardTypeReq(
+          Number(selectedNode.id),
+          values.methodology?.trim() || Strings.empty,
+          values.name?.trim() || Strings.empty,
+          values.description?.trim() || Strings.empty,
+          formatColor(values.color),
+          Number(values.responsableId || 0),
+          Number(values.quantityPicturesCreate || 0),
+          Number(values.quantityAudiosCreate || 0),
+          Number(values.quantityVideosCreate || 0),
+          Number(values.audiosDurationCreate || 0),
+          Number(values.videosDurationCreate || 0),
+          Number(values.quantityPicturesClose || 0),
+          Number(values.quantityAudiosClose || 0),
+          Number(values.quantityVideosClose || 0),
+          Number(values.audiosDurationClose || 0),
+          Number(values.videosDurationClose || 0),
+          Number(values.quantityPicturesPs || 0),
+          Number(values.quantityAudiosPs || 0),
+          Number(values.quantityVideosPs || 0),
+          Number(values.audiosDurationPs || 0),
+          Number(values.videosDurationPs || 0),
+          values.status || Strings.active.toUpperCase()
+        );
+        await updateCardType(updatedCardType).unwrap();
+        handleSucccessNotification(NotificationSuccess.UPDATE);
+      } else if (
+        drawerType === Strings.cardTypesDrawerTypeCreatePreclassifier
+      ) {
+        if (!formData?.cardTypeId) {
+          throw new Error(Strings.cardTypesNoCardTypeIdError);
+        }
+        const newPre = new CreatePreclassifier(
+          values.code?.trim() || Strings.empty,
+          values.description?.trim() || Strings.empty,
+          Number(formData.cardTypeId)
+        );
+        await createPreclassifier(newPre).unwrap();
+        handleSucccessNotification(NotificationSuccess.REGISTER);
+      } else if (
+        drawerType === Strings.cardTypesDrawerTypeUpdatePreclassifier &&
+        selectedNode
+      ) {
+        const payload = {
+          id: Number(selectedNode.id),
+          preclassifierCode: values.code?.trim() || Strings.empty,
+          preclassifierDescription: values.description?.trim() || Strings.empty,
+          status: values.status || Strings.activeStatus,
+        };
+        await updatePreclassifier(payload).unwrap();
+        handleSucccessNotification(NotificationSuccess.UPDATE);
+      }
+
+      setDrawerVisible(false);
+      await handleLoadData(location.state.siteId);
     } catch (error) {
       handleErrorNotification(error);
     } finally {
-      setModalLoading(false);
+      setLoading(false);
     }
   };
 
-  const siteName = location?.state?.siteName || Strings.empty;
+  const handleShowDetails = (node: any) => {
+    setDetailsNode(node);
+    setDetailsVisible(true);
+  };
+  const renderCustomNodeElement = (rd3tProps: any) => {
+    const { nodeDatum } = rd3tProps;
+
+    const isRoot = nodeDatum.__rd3t.depth === 0;
+    const isPreclassifier = nodeDatum.nodeType === "preclassifier";
+
+    const fillColor = isRoot
+      ? "#145695"
+      : isPreclassifier
+      ? "#FFFF00"
+      : "#145695";
+
+    const textStyles = {
+      fontSize: isRoot ? "26px" : "16px",
+      fontWeight: "light",
+      fill: "#000",
+    };
+
+    const handleEditPre = () => {
+      handleDrawerOpen(
+        Strings.cardTypesDrawerTypeUpdatePreclassifier,
+        nodeDatum
+      );
+    };
+    const handleClonePre = () => {
+      handleDrawerOpen(
+        Strings.cardTypesDrawerTypeCreatePreclassifier,
+        nodeDatum
+      );
+    };
+    const handleCancelPre = () => {};
+
+    const preMenu = [
+      {
+        key: "editPre",
+        label: (
+          <button className="w-28 bg-blue-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesEditPreclassifier}
+          </button>
+        ),
+        onClick: handleEditPre,
+      },
+      {
+        key: "clonePre",
+        label: (
+          <button className="w-28 bg-yellow-500 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesClonePreclassifier}
+          </button>
+        ),
+        onClick: handleClonePre,
+      },
+      {
+        key: "cancelPre",
+        label: (
+          <button className="w-28 bg-red-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCancel}
+          </button>
+        ),
+        onClick: handleCancelPre,
+      },
+    ];
+
+    const handleCreateCardType = () => {
+      handleDrawerOpen(Strings.cardTypesDrawerTypeCreateCardType);
+    };
+    const handleCancelRoot = () => {};
+
+    const rootMenu = [
+      {
+        key: "createCT",
+        label: (
+          <button className="w-28 bg-green-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCreate}
+          </button>
+        ),
+        onClick: handleCreateCardType,
+      },
+      {
+        key: "cancelRoot",
+        label: (
+          <button className="w-28 bg-red-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCancel}
+          </button>
+        ),
+        onClick: handleCancelRoot,
+      },
+    ];
+
+    const handleEditCT = () => {
+      handleDrawerOpen(Strings.cardTypesDrawerTypeUpdateCardType, nodeDatum);
+    };
+    const handleCloneCT = () => {
+      handleDrawerOpen(Strings.cardTypesDrawerTypeCreateCardType, nodeDatum);
+    };
+    const handleCreatePre = () => {
+      handleDrawerOpen(Strings.cardTypesDrawerTypeCreatePreclassifier, {
+        cardTypeId: nodeDatum.id,
+      });
+    };
+    const handleCancelCT = () => {};
+
+    const ctMenu = [
+      {
+        key: Strings.cardTypesOptionEdit,
+        label: (
+          <button className="w-28 bg-blue-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesEdit}
+          </button>
+        ),
+        onClick: handleEditCT,
+      },
+      {
+        key: Strings.cardTypesOptionClone,
+        label: (
+          <button className="w-28 bg-yellow-500 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCloneCardType}
+          </button>
+        ),
+        onClick: handleCloneCT,
+      },
+      {
+        key: Strings.cardTypesOptionCreate,
+        label: (
+          <button className="w-28 bg-green-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCreatePreclassifier}
+          </button>
+        ),
+        onClick: handleCreatePre,
+      },
+      {
+        key: Strings.cardTypesOptionCancel,
+        label: (
+          <button className="w-28 bg-red-700 text-white p-2 rounded-md text-xs">
+            {Strings.cardTypesCancel}
+          </button>
+        ),
+        onClick: handleCancelCT,
+      },
+    ];
+
+    if (isPreclassifier) {
+      return (
+        <g>
+          <Dropdown menu={{ items: preMenu }} trigger={["contextMenu"]}>
+            <circle
+              r={18}
+              fill={fillColor}
+              stroke="none"
+              strokeWidth={0}
+              style={{ cursor: "pointer" }}
+              onClick={(e) => {
+                e.stopPropagation();
+
+                handleShowDetails(nodeDatum);
+              }}
+            />
+          </Dropdown>
+          <text x={25} y={5} style={textStyles}>
+            {nodeDatum.name}
+          </text>
+        </g>
+      );
+    }
+
+    if (isRoot) {
+      return (
+        <g>
+          <Dropdown menu={{ items: rootMenu }} trigger={["contextMenu"]}>
+            <circle r={22} fill={fillColor} style={{ cursor: "pointer" }} stroke="none" strokeWidth={0} />
+          </Dropdown>
+          <text
+            x={-200}
+            y={-40}
+            style={{ fontSize: "18px", fill: "#1e88e5", fontWeight: "normal" }}
+          >
+            {Strings.cardType}{" "}
+            {location.state?.siteName || Strings.defaultSiteName}
+          </text>
+        </g>
+      );
+    }
+
+    return (
+      <g>
+        <Dropdown menu={{ items: ctMenu }} trigger={["contextMenu"]}>
+          <circle
+            r={18}
+             stroke="none"
+            strokeWidth={0}
+            fill={fillColor}
+            style={{ cursor: "pointer" }}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleShowDetails(nodeDatum);
+            }}
+          />
+        </Dropdown>
+        <text
+          x={20}
+          y={35}
+          style={{ fontSize: "16px", fill: "#000", fontWeight: "normal" }}
+        >
+          {nodeDatum.name}
+        </text>
+      </g>
+    );
+  };
 
   return (
-    <>
-      <div className="h-full flex flex-col">
-        <div className="flex flex-col gap-2 items-center m-3">
-          <PageTitle mainText={Strings.cardTypesOf} subText={siteName} />
-          <div className="flex flex-col md:flex-row flex-wrap items-center md:justify-between w-full">
-            <div className="flex flex-col md:flex-row items-center flex-1 mb-1 md:mb-0">
-              <Space className="w-full md:w-auto mb-1 md:mb-0">
-                <Input
-                  className="w-full"
-                  onChange={handleOnSearch}
-                  value={querySearch}
-                  addonAfter={<IoIosSearch />}
-                />
-              </Space>
-            </div>
-            <div className="flex mb-1 md:mb-0 md:justify-end w-full md:w-auto">
-              <CustomButton
-                type="success"
-                onClick={handleOnClickCreateButton}
-                className="w-full md:w-auto"
-              >
-                {Strings.create}
-              </CustomButton>
-            </div>
+    <div className="flex flex-col h-full overflow-hidden">
+      <div ref={containerRef} className="relative flex-1 overflow-hidden">
+        {loading && (
+          <div className="absolute inset-0 flex justify-center items-center bg-white bg-opacity-75 z-10">
+            <Spin spinning={loading} tip={Strings.cardTypesLoadingData} />
           </div>
-        </div>
-        <div className="flex-1 overflow-auto hidden lg:block">
-          <CardTypesTable data={data} isLoading={isLoading} rol={rol} />
-        </div>
-        <div className="flex-1 overflow-auto lg:hidden">
-          <PaginatedList
-            dataSource={data}
-            renderItem={(item: CardTypes, index: number) => (
-              <List.Item>
-                <CardTypesCard key={index} data={item} rol={rol} />
-              </List.Item>
-            )}
-            loading={isLoading}
+        )}
+        {!loading && treeData.length > 0 && (
+          <Tree
+            data={treeData}
+            orientation="horizontal"
+            translate={translate}
+            renderCustomNodeElement={renderCustomNodeElement}
+            zoomable
           />
-        </div>
+        )}
       </div>
       <Form.Provider
         onFormFinish={async (_, { values }) => {
-          await handleOnFormCreateFinish(values);
+          await handleOnFormFinish(values);
         }}
       >
-        <ModalForm
-          open={modalIsOpen}
-          onCancel={handleOnCancelButton}
-          FormComponent={RegisterCardTypeForm}
-          title={Strings.createCardType.concat(` ${siteName}`)}
-          isLoading={modalIsLoading}
-        />
+        <Drawer
+          title={
+            drawerType === Strings.cardTypesDrawerTypeCreateCardType
+              ? formData?.name?.includes(Strings.cardTypesCloneSuffix)
+                ? Strings.cardTypesCloneCardType
+                : Strings.cardTypesCreateCardType
+              : drawerType === Strings.cardTypesDrawerTypeUpdateCardType
+              ? Strings.cardTypesUpdateCardType
+              : drawerType === Strings.cardTypesDrawerTypeCreatePreclassifier
+              ? formData?.description?.includes(Strings.cardTypesCloneSuffix)
+                ? Strings.cardTypesClonePreclassifier
+                : Strings.cardTypesCreatePreclassifier
+              : drawerType === Strings.cardTypesDrawerTypeUpdatePreclassifier
+              ? Strings.cardTypesUpdatePreclassifier
+              : Strings.empty
+          }
+          placement={isMobile ? "bottom" : "right"}
+          width={isMobile ? "100%" : 400}
+          onClose={handleDrawerClose}
+          open={drawerVisible}
+          destroyOnClose
+          mask={false}
+        >
+          {drawerType === Strings.cardTypesDrawerTypeCreateCardType && (
+            <RegisterCardTypeForm
+              form={createForm}
+              onFinish={handleOnFormFinish}
+              rol={rol}
+              initialValues={formData}
+            />
+          )}
+          {drawerType === Strings.cardTypesDrawerTypeUpdateCardType && (
+            <UpdateCardTypeForm
+              form={updateForm}
+              initialValues={formData}
+              onFinish={handleOnFormFinish}
+            />
+          )}
+          {drawerType === Strings.cardTypesDrawerTypeCreatePreclassifier && (
+            <RegisterPreclassifierForm2
+              form={createPreForm}
+              initialValues={formData}
+            />
+          )}
+          {drawerType === Strings.cardTypesDrawerTypeUpdatePreclassifier && (
+            <UpdatePreclassifierForm2
+              form={updatePreForm}
+              initialValues={formData}
+            />
+          )}
+        </Drawer>
       </Form.Provider>
-    </>
+      <Drawer
+        title={Strings.details}
+        placement={isMobile ? "bottom" : "right"}
+        width={isMobile ? "100%" : 400}
+        onClose={() => setDetailsVisible(false)}
+        open={detailsVisible}
+        destroyOnClose
+        mask={false}
+      >
+        {detailsNode && detailsNode.nodeType === "cardType" && (
+          <CardTypeDetails nodeData={detailsNode} />
+        )}
+        {detailsNode && detailsNode.nodeType === "preclassifier" && (
+          <PreclassifierDetails nodeData={detailsNode} />
+        )}
+      </Drawer>
+    </div>
   );
 };
 
-export default CardTypess;
+export default CardTypesTree;

--- a/src/pages/cardtypes/components/CardTypeDetails.tsx
+++ b/src/pages/cardtypes/components/CardTypeDetails.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect } from "react";
+import { Descriptions } from "antd";
+import Strings from "../../../utils/localizations/Strings";
+
+interface CardTypeDetailsProps {
+  nodeData: any;
+}
+
+const CardTypeDetails: React.FC<CardTypeDetailsProps> = ({ nodeData }) => {
+  useEffect(() => {
+  }, [nodeData]);
+
+  const renderStatus = (status: string) => {
+    switch (status) {
+      case Strings.activeStatus:
+        return Strings.active;
+      case Strings.detailsOptionS:
+        return Strings.detailsStatusSuspended;
+      case Strings.C:
+        return Strings.tagStatusCanceled;
+      default:
+        return Strings.empty;
+    }
+  };
+
+  if (!nodeData) {
+    return <div className="text-center">{Strings.noData}</div>;
+  }
+
+  return (
+    <div className="p-4 bg-white shadow-md rounded-md border border-gray-300">
+      <Descriptions bordered column={1}>
+        <Descriptions.Item label={Strings.cardTypeDetailsMethodology}>
+          {nodeData.methodology && nodeData.cardTypeMethodology
+            ? `${nodeData.methodology} - ${nodeData.cardTypeMethodology}`
+            : nodeData.methodology || nodeData.cardTypeMethodology || Strings.notSpecified}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.cardTypeDetailsName}>
+          {nodeData.name || ""}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.cardTypeDetailsDescription}>
+          {nodeData.description || ""}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.cardTypeDetailsColor}>
+          <div
+            className="w-16 h-6 rounded-md"
+            style={{
+              backgroundColor: `#${nodeData.color}`,
+              border: "1px solid #ccc",
+            }}
+          />
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.cardTypeDetailsResponsible}>
+          {nodeData.responsableName || `ID: ${nodeData.responsableId}` || ""}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.cardTypeDetailsStatus}>
+          {renderStatus(nodeData.status)}
+        </Descriptions.Item>
+      </Descriptions>
+    </div>
+  );
+};
+
+export default CardTypeDetails;

--- a/src/pages/cardtypes/components/RegisterCardTypeFormOriginal.tsx
+++ b/src/pages/cardtypes/components/RegisterCardTypeFormOriginal.tsx
@@ -1,0 +1,397 @@
+import {
+    Button,
+    ColorPicker,
+    ColorPickerProps,
+    Form,
+    FormInstance,
+    GetProp,
+    Input,
+    InputNumber,
+    Select,
+    Tooltip,
+  } from "antd";
+  import Strings from "../../../utils/localizations/Strings";
+  import { BsCardText } from "react-icons/bs";
+  import { AiOutlinePicture } from "react-icons/ai";
+  import { LuTextCursor } from "react-icons/lu";
+  import { useEffect, useMemo, useState } from "react";
+  import { useGetSiteResponsiblesMutation } from "../../../services/userService";
+  import { useAppSelector } from "../../../core/store";
+  import { selectSiteId } from "../../../core/genericReducer";
+  import { Responsible } from "../../../data/user/user";
+  import { CardTypesCatalog } from "../../../data/cardtypes/cardTypes";
+  import { IoHeadsetOutline } from "react-icons/io5";
+  import { GoDeviceCameraVideo } from "react-icons/go";
+  import { useGetCardTypesCatalogsMutation } from "../../../services/CardTypesService";
+  import { QuestionCircleOutlined } from "@ant-design/icons";
+  
+  type Color = Extract<GetProp<ColorPickerProps, "value">, string | { cleared: any }>;
+  
+  interface FormProps {
+    form: FormInstance;
+  }
+  
+  const RegisterCardTypeFormOriginal = ({ form }: FormProps) => {
+    const [getResponsibles] = useGetSiteResponsiblesMutation();
+    const [getCardTypesCatalogs] = useGetCardTypesCatalogsMutation();
+    const siteId = useAppSelector(selectSiteId);
+    const [responsibles, setResponsibles] = useState<Responsible[]>([]);
+    const [catalogs, setCatalogs] = useState<CardTypesCatalog[]>([]);
+    const [color, setColor] = useState<Color>(Strings.white);
+  
+    const bgColor = useMemo<string>(
+      () => (typeof color === "string" ? color : color!.toHexString()),
+      [color]
+    );
+  
+    const btnStyle: React.CSSProperties = {
+      backgroundColor: bgColor,
+    };
+  
+    const handleGetData = async () => {
+      try {
+        const response1 = await getResponsibles(siteId).unwrap();
+        const response2 = await getCardTypesCatalogs().unwrap();
+        setResponsibles(response1);
+        setCatalogs(response2);
+    
+        console.log("Catalogs Data:", response2); // Verifica los datos cargados
+      } catch (error) {
+        console.error("Error fetching data:", error);
+      }
+    };
+    
+  
+    useEffect(() => {
+      handleGetData();
+    }, []);
+  
+    const responsibleOptions = () => {
+      return responsibles.map((responsible) => ({
+        value: responsible.id,
+        label: responsible.name,
+      }));
+    };
+    const catalogsOptions = () => {
+      return catalogs.map((catalog) => ({
+        value: `${catalog.cardTypeMethodologyName} - ${catalog.cardTypeMethodology}`,
+        label: `${catalog.cardTypeMethodologyName} - ${catalog.cardTypeMethodology}`,
+      }));
+    };
+    
+    console.log("Catalog Options:", catalogsOptions());
+
+  
+    return (
+      <Form form={form}>
+        <div className="flex flex-col">
+          {/* Section: Card Type Methodology and Name */}
+          <div className="flex flex-row justify-between flex-wrap items-center">
+            <Form.Item
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredMethodology }]}
+              name="cardTypeMethodology"
+              className="flex-1 mr-1"
+            >
+              <Select
+                size="large"
+                placeholder={Strings.cardTypeMethodology}
+                options={catalogsOptions()}
+              
+              />
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeMethodologyTooltip}>
+              <QuestionCircleOutlined className="mb-6 ml-1 mr-2 text-sm text-blue-500" />
+            </Tooltip>
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredCardTypeName },
+                { max: 45 },
+              ]}
+              className="flex-1"
+            >
+              <Input
+                addonBefore={<LuTextCursor />}
+                size="large"
+                maxLength={45}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+  
+          {/* Section: Description */}
+          <div className="flex items-center">
+            <Form.Item
+              name="description"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredDescription },
+                { max: 100 },
+              ]}
+              className="flex-grow"
+            >
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeDescriptionTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+  
+          {/* Section: Color and Responsible */}
+          <div className="flex flex-row flex-wrap items-center">
+            <Form.Item
+              name="color"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredColor }]}
+              className="mr-3"
+            >
+                 <ColorPicker
+                value={color}
+                onChange={(selectedColor) => {
+                  const bgColor =
+                    typeof selectedColor === "string"
+                      ? selectedColor
+                      : selectedColor.toHexString();
+                  const colorWithoutHash = bgColor.replace("#", "");
+                  setColor(`#${colorWithoutHash}`);
+                  form.setFieldValue("color", colorWithoutHash);
+                }}
+              >
+                <Button size="large" className="w-32 border" style={btnStyle}>
+                  {Strings.color}
+                </Button>
+              </ColorPicker>
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeColorTooltip}>
+              <QuestionCircleOutlined className="mb-6 mr-2 text-sm text-blue-500" />
+            </Tooltip>
+            <Form.Item
+              name="responsableId"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredResponsableId }]}
+              className="w-60"
+            >
+              <Select
+                size="large"
+                placeholder={Strings.responsible}
+                options={responsibleOptions()}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.responsibleTooltip}>
+              <QuestionCircleOutlined className="mb-6 ml-2 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+  
+          {/* Section: At Creation */}
+          <h1 className="font-semibold">{Strings.atCreation}</h1>
+          <div className="flex flex-col">
+            <div className="flex items-center">
+              <Form.Item name="quantityPicturesCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesCreateTooltip}>
+                <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityVideosCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.quantityVideos}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6  mr-2 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="videosDurationCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityAudiosCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.quantityAudios}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="audiosDurationCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+  
+          {/* Section: At Provisional Solution */}
+          <h1 className="font-semibold">{Strings.atProvisionalSolution}</h1>
+          <div className="flex flex-col">
+            <div className="flex items-center">
+              <Form.Item name="quantityPicturesPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesPsTooltip}>
+                <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityVideosPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.quantityVideos}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2  mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="videosDurationPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationPsTooltip}>
+                <QuestionCircleOutlined className="ml-2  mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityAudiosPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.quantityAudios}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 text-sm mb-6  text-blue-500" />
+              </Tooltip>
+              <Form.Item name="audiosDurationPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 text-sm mb-6  text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+  
+          {/* Section: At Definitive Solution */}
+          <h1 className="font-semibold">{Strings.atDefinitiveSolution}</h1>
+          <div className="flex flex-col">
+            <div className="flex items-center">
+              <Form.Item name="quantityPicturesClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesCloseTooltip}>
+                <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityVideosClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.quantityVideos}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="videosDurationClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex items-center gap-1">
+              <Form.Item name="quantityAudiosClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.quantityAudios}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 mr-2 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="audiosDurationClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+        </div>
+      </Form>
+    );
+  };
+  export default RegisterCardTypeFormOriginal;
+  

--- a/src/pages/cardtypes/components/RegisterCardTypeFormOriginal.tsx
+++ b/src/pages/cardtypes/components/RegisterCardTypeFormOriginal.tsx
@@ -55,7 +55,7 @@ import {
         setResponsibles(response1);
         setCatalogs(response2);
     
-        console.log("Catalogs Data:", response2); // Verifica los datos cargados
+        console.log("Catalogs Data:", response2);
       } catch (error) {
         console.error("Error fetching data:", error);
       }

--- a/src/pages/cardtypes/components/UpdateCardType.tsx
+++ b/src/pages/cardtypes/components/UpdateCardType.tsx
@@ -15,9 +15,10 @@ import {
 } from "../../../core/genericReducer";
 import ModalUpdateForm from "../../../components/ModalUpdateForm";
 import { UpdateCardTypeReq } from "../../../data/cardtypes/cardTypes.request";
-import UpdateCardTypeForm from "./UpdateCardTypeForm";
+
 import { AggregationColor } from "antd/es/color-picker/color";
 import { useGetCardTypeMutation, useUpdateCardTypeMutation } from '../../../services/CardTypesService';
+import UpdateCardTypeFormOriginal from "./UpdateCardTypeFormOriginal";
 
 interface ButtonEditProps {
   id: string;
@@ -100,7 +101,7 @@ const UpdateCardType = ({ id }: ButtonEditProps) => {
         <ModalUpdateForm
           open={modalIsOpen}
           onCancel={handleOnCancelButton}
-          FormComponent={UpdateCardTypeForm}
+          FormComponent={UpdateCardTypeFormOriginal}
           title={Strings.updateCardType}
           isLoading={modalIsLoading}
         />

--- a/src/pages/cardtypes/components/UpdateCardTypeFormOriginal.tsx
+++ b/src/pages/cardtypes/components/UpdateCardTypeFormOriginal.tsx
@@ -149,7 +149,7 @@ import {
                   type="primary"
                   style={btnStyle}
                 >
-                  Color
+                  {Strings.cardTypeDetailsColor}
                 </Button>
               </ColorPicker>
             </Form.Item>

--- a/src/pages/cardtypes/components/UpdateCardTypeFormOriginal.tsx
+++ b/src/pages/cardtypes/components/UpdateCardTypeFormOriginal.tsx
@@ -1,0 +1,390 @@
+import {
+    Button,
+    ColorPicker,
+    ColorPickerProps,
+    Form,
+    FormInstance,
+    GetProp,
+    Input,
+    InputNumber,
+    Select,
+    Tooltip,
+  } from "antd";
+  import Strings from "../../../utils/localizations/Strings";
+  import { BsCardText } from "react-icons/bs";
+  import { AiOutlinePicture } from "react-icons/ai";
+  import { LuTextCursor } from "react-icons/lu";
+  import { CardTypeUpdateForm } from "../../../data/cardtypes/cardTypes";
+  import { useAppSelector } from "../../../core/store";
+  import {
+    selectCurrentRowData,
+    selectSiteId,
+  } from "../../../core/genericReducer";
+  import { useEffect, useMemo, useState } from "react";
+  import { useGetSiteResponsiblesMutation } from "../../../services/userService";
+  import { Responsible } from "../../../data/user/user";
+  import { GoDeviceCameraVideo } from "react-icons/go";
+  import { IoHeadsetOutline } from "react-icons/io5";
+  import { useGetStatusMutation } from "../../../services/statusService";
+  import { Status } from "../../../data/status/status";
+  import { QuestionCircleOutlined } from "@ant-design/icons";
+  
+  type Color = Extract<
+    GetProp<ColorPickerProps, "value">,
+    string | { cleared: any }
+  >;
+  
+  interface FormProps {
+    form: FormInstance;
+  }
+  
+  const UpdateCardTypeFormOriginal = ({ form }: FormProps) => {
+    const rowData = useAppSelector(
+      selectCurrentRowData
+    ) as unknown as CardTypeUpdateForm;
+    const [getResponsibles] = useGetSiteResponsiblesMutation();
+    const [getStatus] = useGetStatusMutation();
+    const siteId = useAppSelector(selectSiteId);
+    const [responsibles, setResponsibles] = useState<Responsible[]>([]);
+    const [statuses, setStatuses] = useState<Status[]>([]);
+    const [color, setColor] = useState<Color>(Strings.empty);
+  
+    const bgColor = useMemo<string>(
+      () => (typeof color === "string" ? color : color!.toHexString()),
+      [color]
+    );
+  
+    const btnStyle: React.CSSProperties = {
+      backgroundColor: bgColor,
+    };
+  
+    const handleGetData = async () => {
+      const [responsiblesResponse, statusResponse] = await Promise.all([
+        getResponsibles(siteId).unwrap(),
+        getStatus().unwrap(),
+      ]);
+      setResponsibles(responsiblesResponse);
+      setStatuses(statusResponse);
+    };
+  
+    const responsibleOptions = () => {
+      return responsibles.map((responsible) => ({
+        value: responsible.id,
+        label: responsible.name,
+      }));
+    };
+    const statusOptions = () => {
+      return statuses.map((status) => ({
+        value: status.statusCode,
+        label: status.statusName,
+      }));
+    };
+    useEffect(() => {
+      form.setFieldsValue({ ...rowData });
+      setColor(`#${rowData.color}`);
+      handleGetData();
+    }, []);
+    return (
+      <Form form={form}>
+        <div className="flex flex-col">
+          <div className="flex flex-row justify-between flex-wrap">
+            <Form.Item className="hidden" name="id">
+              <Input />
+            </Form.Item>
+            <Form.Item className="hidden" name="methodology">
+              <Input />
+            </Form.Item>
+            <Form.Item
+              name="name"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredCardTypeName },
+                { max: 45 },
+              ]}
+              className="flex-1"
+            >
+              <Input
+                addonBefore={<LuTextCursor />}
+                size="large"
+                maxLength={45}
+                placeholder={Strings.name}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeNameTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex items-center w-full">
+            <Form.Item
+              name="description"
+              validateFirst
+              rules={[
+                { required: true, message: Strings.requiredDescription },
+                { max: 100 },
+              ]}
+              className="flex-grow"
+            >
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeDescriptionTooltip}>
+              <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <div className="flex flex-row flex-wrap">
+            <Form.Item
+              name="color"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredColor }]}
+              className="mr-3"
+            >
+              <ColorPicker value={color} onChange={setColor}>
+                <Button
+                  size="large"
+                  className="w-32"
+                  type="primary"
+                  style={btnStyle}
+                >
+                  Color
+                </Button>
+              </ColorPicker>
+            </Form.Item>
+            <Tooltip title={Strings.cardTypeColorTooltip}>
+              <QuestionCircleOutlined className="ml-0 mr-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+            <Form.Item
+              name="responsableId"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredResponsableId }]}
+              className="w-60"
+            >
+              <Select
+                size="large"
+                placeholder={Strings.responsible}
+                options={responsibleOptions()}
+                className=""
+              />
+            </Form.Item>
+            <Tooltip title={Strings.responsibleTooltip}>
+              <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+            </Tooltip>
+          </div>
+          <h1 className="font-semibold">{Strings.atCreation}</h1>
+          <div className="flex flex-col">
+            <div className="flex">
+              <Form.Item name="quantityPicturesCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesCreateTooltip}>
+                <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex gap-1">
+              <Form.Item name="quantityVideosCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.quantityVideos}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="videosDurationCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex gap-1">
+              <Form.Item name="quantityAudiosCreate" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.quantityAudios}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosCreateTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item
+                name="audiosDurationCreate"
+                validateFirst
+                className="mr-2"
+              >
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationCreateTooltip}>
+                <QuestionCircleOutlined className="mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+          <h1 className="font-semibold">{Strings.atProvisionalSolution}</h1>
+          <div className="flex flex-col">
+            <div className="flex">
+              <Form.Item name="quantityPicturesPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesPsTooltip}>
+                <QuestionCircleOutlined className="ml-3 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex gap-1">
+              <Form.Item name="quantityVideosPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.videosCreatePs}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="videosDurationPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+            <div className="flex gap-1">
+              <Form.Item name="quantityAudiosPs" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.audiosCreatePs}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosPsTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              <Form.Item name="audiosDurationPs" validateFirst className="mr-2">
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationPsTooltip}>
+                <QuestionCircleOutlined className="ml-0 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+          <h1 className="font-semibold">{Strings.atDefinitiveSolution}</h1>
+          <div className="flex flex-col">
+            <div className="flex items-center w-full">
+              <Form.Item name="quantityPicturesClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<AiOutlinePicture />}
+                  placeholder={Strings.quantityPictures}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityPicturesCloseTooltip}>
+                <QuestionCircleOutlined className="ml-3 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+  
+            <div className="flex gap-1 items-center">
+              <Form.Item name="quantityVideosClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.quantityVideos}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityVideosCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+  
+              <Form.Item name="videosDurationClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<GoDeviceCameraVideo />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.videosDurationCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+  
+            <div className="flex gap-1 items-center">
+              <Form.Item name="quantityAudiosClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  max={255}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.quantityAudios}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.quantityAudiosCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+  
+              <Form.Item name="audiosDurationClose" validateFirst>
+                <InputNumber
+                  size="large"
+                  maxLength={10}
+                  addonBefore={<IoHeadsetOutline />}
+                  placeholder={Strings.durationInSeconds}
+                />
+              </Form.Item>
+              <Tooltip title={Strings.audiosDurationCloseTooltip}>
+                <QuestionCircleOutlined className="ml-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+            </div>
+          </div>
+              <div className="flex">
+              <Form.Item className="w-60" name="status">
+            <Select size="large" options={statusOptions()} />
+          </Form.Item>
+          <Tooltip title={Strings.statusCardTypeTooltip}>
+                <QuestionCircleOutlined className="ml-3.5 mr-2 mb-6 text-sm text-blue-500" />
+              </Tooltip>
+              </div>
+        </div>
+      </Form>
+    );
+  };
+  
+  export default UpdateCardTypeFormOriginal;
+  

--- a/src/pages/cardtypes/components/preclassifier/PreclassifierDetails.tsx
+++ b/src/pages/cardtypes/components/preclassifier/PreclassifierDetails.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Descriptions } from "antd";
+import Strings from "../../../../utils/localizations/Strings";
+
+interface PreclassifierDetailsProps {
+  nodeData: any;
+}
+
+const PreclassifierDetails: React.FC<PreclassifierDetailsProps> = ({
+  nodeData,
+}) => {
+  if (!nodeData) {
+    return <div className="text-center">{Strings.noData}</div>;
+  }
+
+  return (
+    <div className="p-4 bg-white shadow-md rounded-md border border-gray-300">
+      <Descriptions bordered column={1}>
+        <Descriptions.Item label={Strings.preclassifierDetailsCode}>
+          {nodeData.preclassifierCode || Strings.empty}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.preclassifierDetailsDescription}>
+          {nodeData.preclassifierDescription || Strings.empty}
+        </Descriptions.Item>
+        <Descriptions.Item label={Strings.preclassifierDetailsStatus}>
+          {nodeData.status || ""}
+        </Descriptions.Item>
+      </Descriptions>
+    </div>
+  );
+};
+
+export default PreclassifierDetails;

--- a/src/pages/cardtypes/components/preclassifier/RegisterPreclassifierForm.tsx
+++ b/src/pages/cardtypes/components/preclassifier/RegisterPreclassifierForm.tsx
@@ -1,0 +1,82 @@
+import { useEffect } from "react";
+import { Button, Form, FormInstance, Input, Tooltip } from "antd";
+import { BsCardText } from "react-icons/bs";
+import { CiBarcode } from "react-icons/ci";
+import { QuestionCircleOutlined } from "@ant-design/icons";
+import Strings from "../../../../utils/localizations/Strings";
+
+interface FormProps {
+  form: FormInstance;
+  initialValues?: {
+    id?: number;
+    code?: string;
+    description?: string;
+    status?: string;
+  };
+}
+
+const RegisterPreclassifierForm2 = ({ form, initialValues }: FormProps) => {
+  // Efecto para setear valores iniciales
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        code: initialValues.code,
+        description: initialValues.description,
+      });
+    }
+  }, [initialValues, form]);
+
+  return (
+    <Form form={form}>
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <Form.Item
+              name="code"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredCode }]}
+            >
+              <Input
+                size="large"
+                maxLength={3}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+            </Form.Item>
+          </div>
+          <Tooltip title={Strings.preclassifierCodeTooltip}>
+            <QuestionCircleOutlined className="text-blue-500 mt-3 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <Form.Item
+              name="description"
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredDescription }]}
+            >
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+            </Form.Item>
+          </div>
+          <Tooltip title={Strings.preclassifierDescriptionTooltip}>
+            <QuestionCircleOutlined className="text-blue-500 mt-3 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
+        <div className="flex justify-end gap-4 mt-4">
+          <Button type="primary" htmlType="submit">
+            {Strings.save}
+          </Button>
+        </div>
+      </div>
+    </Form>
+  );
+};
+
+export default RegisterPreclassifierForm2;

--- a/src/pages/cardtypes/components/preclassifier/RegisterPreclassifierForm.tsx
+++ b/src/pages/cardtypes/components/preclassifier/RegisterPreclassifierForm.tsx
@@ -16,7 +16,7 @@ interface FormProps {
 }
 
 const RegisterPreclassifierForm2 = ({ form, initialValues }: FormProps) => {
-  // Efecto para setear valores iniciales
+// Effect to set initial values
   useEffect(() => {
     if (initialValues) {
       form.setFieldsValue({

--- a/src/pages/cardtypes/components/preclassifier/UpdatePreclassifierForm.tsx
+++ b/src/pages/cardtypes/components/preclassifier/UpdatePreclassifierForm.tsx
@@ -1,0 +1,129 @@
+// ./components/preclassifier/UpdatePreclassifierForm2.tsx
+import React, { useEffect, useState } from "react";
+import { Button, Form, FormInstance, Input, Select, Tooltip } from "antd";
+import { BsCardText } from "react-icons/bs";
+import { CiBarcode } from "react-icons/ci";
+import { QuestionCircleOutlined } from "@ant-design/icons";
+import { useGetStatusMutation } from "../../../../services/statusService";
+import { Status } from "../../../../data/status/status";
+import Strings from "../../../../utils/localizations/Strings";
+
+interface UpdatePreclassifierForm2Props {
+  form: FormInstance;
+  // Pasamos un 'initialValues' con la data del preclassifier a editar
+  initialValues?: {
+    id?: number;
+    preclassifierCode?: string;
+    preclassifierDescription?: string;
+    status?: string;
+  };
+}
+
+const UpdatePreclassifierForm2: React.FC<UpdatePreclassifierForm2Props> = ({
+  form,
+  initialValues,
+}) => {
+  const [getStatus] = useGetStatusMutation();
+  const [statuses, setStatuses] = useState<Status[]>([]);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const statusResponse = await getStatus().unwrap();
+        setStatuses(statusResponse);
+      } catch (err) {
+        console.error("Error fetching status", err);
+      }
+    })();
+  }, [getStatus]);
+
+  // Cuando cambie 'initialValues', seteamos los campos en el form
+  useEffect(() => {
+    if (initialValues) {
+      form.setFieldsValue({
+        id: initialValues.id,
+        code: initialValues.preclassifierCode,
+        description: initialValues.preclassifierDescription,
+        status: initialValues.status ?? "A",
+      });
+    }
+  }, [initialValues, form]);
+
+  const statusOptions = () => {
+    return statuses.map((st) => ({
+      value: st.statusCode,
+      label: st.statusName,
+    }));
+  };
+
+  return (
+    <Form form={form} layout="vertical">
+      <Form.Item name="id" className="hidden">
+        <Input />
+      </Form.Item>
+
+      <div className="flex flex-col gap-4">
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <Form.Item
+              name="code"
+              label={Strings.code}
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredCode }]}
+            >
+              <Input
+                size="large"
+                maxLength={3}
+                addonBefore={<CiBarcode />}
+                placeholder={Strings.code}
+              />
+            </Form.Item>
+          </div>
+          <Tooltip title={Strings.preclassifierCodeTooltip}>
+            <QuestionCircleOutlined className="text-blue-500 mt-10 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <Form.Item
+              name="description"
+              label={Strings.description}
+              validateFirst
+              rules={[{ required: true, message: Strings.requiredDescription }]}
+            >
+              <Input
+                size="large"
+                maxLength={100}
+                addonBefore={<BsCardText />}
+                placeholder={Strings.description}
+              />
+            </Form.Item>
+          </div>
+          <Tooltip title={Strings.preclassifierDescriptionTooltip}>
+            <QuestionCircleOutlined className="text-blue-500 mt-10 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+
+        <div className="flex items-start gap-2">
+          <div className="flex-1">
+            <Form.Item name="status" label={Strings.status}>
+              <Select size="large" options={statusOptions()} />
+            </Form.Item>
+          </div>
+          <Tooltip title={Strings.preclassifierStatusTooltip}>
+            <QuestionCircleOutlined className="text-blue-500 mt-10 text-sm cursor-pointer" />
+          </Tooltip>
+        </div>
+      </div>
+
+      <div className="flex justify-end gap-4 mt-4">
+        <Button type="primary" htmlType="submit">
+          {Strings.save}
+        </Button>
+      </div>
+    </Form>
+  );
+};
+
+export default UpdatePreclassifierForm2;

--- a/src/pages/cardtypes/components/preclassifier/UpdatePreclassifierForm.tsx
+++ b/src/pages/cardtypes/components/preclassifier/UpdatePreclassifierForm.tsx
@@ -10,7 +10,7 @@ import Strings from "../../../../utils/localizations/Strings";
 
 interface UpdatePreclassifierForm2Props {
   form: FormInstance;
-  // Pasamos un 'initialValues' con la data del preclassifier a editar
+  //We pass an 'initialValues' with the preclassifier data to edit
   initialValues?: {
     id?: number;
     preclassifierCode?: string;
@@ -37,14 +37,14 @@ const UpdatePreclassifierForm2: React.FC<UpdatePreclassifierForm2Props> = ({
     })();
   }, [getStatus]);
 
-  // Cuando cambie 'initialValues', seteamos los campos en el form
+  //When 'initialValues' changes, we set the fields in the form
   useEffect(() => {
     if (initialValues) {
       form.setFieldsValue({
         id: initialValues.id,
         code: initialValues.preclassifierCode,
         description: initialValues.preclassifierDescription,
-        status: initialValues.status ?? "A",
+        status: initialValues.status ?? Strings.activeStatus,
       });
     }
   }, [initialValues, form]);

--- a/src/pages/level/Levels.tsx
+++ b/src/pages/level/Levels.tsx
@@ -157,6 +157,8 @@ const Levels = ({}: Props) => {
     setContextMenuVisible(false);
   };
 
+  
+
   const handleUpdateLevel = () => {
     closeAllDrawers();
     setDrawerType("update");
@@ -176,7 +178,8 @@ const Levels = ({}: Props) => {
     createForm.resetFields();
 
     if (selectedNode?.data) {
-      createForm.setFieldsValue(selectedNode.data);
+      const { levelMachineId, ...filteredData } = selectedNode.data;
+      createForm.setFieldsValue(filteredData);
     }
 
     setDrawerVisible(true);
@@ -264,8 +267,24 @@ const Levels = ({}: Props) => {
 
     const handleLeftClick = (e: React.MouseEvent<SVGGElement>) => {
       e.stopPropagation();
-      handleShowDetails(nodeDatum.id);
+      handleShowDetails(nodeDatum.id); 
     };
+    
+    return (
+      <g onClick={handleLeftClick} onContextMenu={handleContextMenu}>
+        <circle r={15} fill={fillColor} stroke="none" strokeWidth={0} />
+        <text
+          fill="black"
+          strokeWidth={nodeDatum.id === "0" ? "0.8" : "0"}
+          x={nodeDatum.id === "0" ? -200 : 20}
+          y={nodeDatum.id === "0" ? 0 : 20}
+          style={{ fontSize: "14px" }}
+        >
+          {nodeDatum.name}
+        </text>
+      </g>
+    );
+    
 
     return (
       <g onContextMenu={handleContextMenu} onClick={handleLeftClick}>

--- a/src/pages/level/Levels.tsx
+++ b/src/pages/level/Levels.tsx
@@ -306,10 +306,6 @@ const Levels = ({}: Props) => {
 
   return (
     <div className="h-full flex flex-col">
-      <div className="flex flex-col gap-2 items-center py-4">
-        <PageTitle mainText={Strings.levelsOf} subText={siteName} />
-      </div>
-
       <div
         ref={containerRef}
         className="flex-grow bg-white border border-gray-300 shadow-md rounded-md m-4 p-4 relative overflow-hidden"

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -520,6 +520,78 @@ static companyLogoTooltip = "Upload the company logo in image format.";
     static no = "No";
     static detailsStatusCancelled = "Cancelled";
     static for = "for"
-    
 
+    static errorFetchingData = "Error fetching data"
+    static namePlaceholder = "Enter the name"
+    static descriptionPlaceholder = "Enter the description"
+    static responsiblePlaceholder = "Select a responsible"
+
+     // General Placeholders
+  static cardTypeTreeNamePlaceholder = "Enter the name";
+  static cardTypeTreeDescriptionPlaceholder = "Enter the description";
+  static cardTypeTreeResponsiblePlaceholder = "Select a responsible";
+  static cardTypeTreeStatusPlaceholder = "Select a status";
+  static cardTypeTreeColorPlaceholder = "Pick a color";
+
+  // Placeholders for Quantity Fields
+  static cardTypeTreeQuantityPicturesPlaceholder = "Enter the number of pictures";
+  static cardTypeTreeQuantityVideosPlaceholder = "Enter the number of videos";
+  static cardTypeTreeQuantityAudiosPlaceholder = "Enter the number of audios";
+
+  // Titles or Section Labels
+  static cardTypeTreeAtCreation = "At Creation";
+  static cardTypeTreeAtProvisionalSolution = "At Provisional Solution";
+  static cardTypeTreeAtDefinitiveSolution = "At Definitive Solution";
+
+  // Error Messages
+  static cardTypeTreeRequiredCardTypeName = "Card type name is required";
+  static cardTypeTreeRequiredDescription = "Description is required";
+  static cardTypeTreeRequiredResponsableId = "Responsible is required";
+  static cardTypeTreeRequiredColor = "Color is required";
+
+  // Notifications
+  static cardTypeTreeSuccessCardTypeUpdated = "Card type successfully updated!";
+  static cardTypeTreeErrorFetchingData = "Error fetching data";
+
+
+/* Card Types and Preclassifier tree*/
+ static cardTypesDrawerTypeCreateCardType = "createCardType";
+ static cardTypesDrawerTypeUpdateCardType = "updateCardType";
+ static cardTypesDrawerTypeCreatePreclassifier = "createPreclassifier";
+ static cardTypesDrawerTypeUpdatePreclassifier = "updatePreclassifier";
+ static cardTypesCreate = "Create Card Type";
+ static cardTypesCancel = "Cancel";
+ static cardTypesEdit = "Edit Card Type";
+ static cardTypesEditPreclassifier = "Edit Preclassifier";
+ static cardTypesCloneCardType = "Clone Card Type";
+ static cardTypesClonePre = "Clone Preclassifier";
+ static cardTypesCreatePreclassifier = "Create Preclassifier";
+ static cardTypesUpdatePreclassifier = "Edit Preclassifier";
+ static cardTypesRoot = "Root";
+ static cardTypesCloneSuffix = "(Clone)";
+ static cardTypesMethodologyError = "Card Type Methodology is required for creation.";
+ static cardTypesLoadingData = "Loading data...";
+ static cardTypesUpdateCardType = "Edit Card Type";
+ static cardTypesCreateCardType = "Create Card Type";
+ static cardTypesClonePreclassifier = "Clone preclassifier"
+ static cardTypesErrorFetchingData = "Error fetching data";
+ static cardTypesNoCardTypeIdError = "No cardTypeId found to create a preclassifier.";
+ static cardTypesOptionEdit = "editCT"
+ static cardTypesOptionClone = "cloneCT"
+ static cardTypesOptionCreate = "createPre"
+ static cardTypesOptionCancel = "cancelCT"
+
+ static cardTypeDetailsTitle = "Card Type Details";
+ static cardTypeDetailsMethodology = "Methodology";
+ static cardTypeDetailsName = "Name";
+ static cardTypeDetailsDescription = "Description";
+ static cardTypeDetailsColor = "Color";
+ static cardTypeDetailsResponsible = "Responsible";
+ static cardTypeDetailsStatus = "Status";
+
+ static preclassifierDetailsTitle = "Preclassifier Details";
+ static preclassifierDetailsCode = "Code";
+ static preclassifierDetailsDescription = "Description";
+ static preclassifierDetailsStatus = "Status";
+ static notSpecified = "Not Specified"
 }


### PR DESCRIPTION
### Feature / Bug Description
- Combine the pages of Card Types and Preclassifier using a dynamic tree

### Solution
- Use the react-d3-tree library
- Use the Drawer from Ant Design to show the forms
- Validate the duplicated name of a Card Type
- Add a Spin element from Ant Design

### Notes
- The Details component pending to be confirmed. If it has to be implemented, it would be good if it were in another PR.
- There was a correction with the card type status.
- There was a correction with the Levels clone function, the machine id can´t be duplicated.

### Tickets
- [TICKET](https://one-sm.atlassian.net/browse/KAN-43)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/dbf358dc-377b-4c31-81ba-d75147b4ff25)
![image](https://github.com/user-attachments/assets/024ab9de-71f2-49bd-b12e-bd7dacb64dd8)