### PR TITLE
KAN - 68 Corrections for Levels and Card Types tree

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -572,7 +572,7 @@ preclassifierDetailsCode: "Code",
 preclassifierDetailsDescription: "Description",
 preclassifierDetailsStatus: "Status",
 notSpecified: "Not Specified",
-
+false: "false"
 
     },
   },
@@ -1202,7 +1202,7 @@ preclassifierDetailsCode: "Código",
 preclassifierDetailsDescription: "Descripción",
 preclassifierDetailsStatus: "Estado",
 notSpecified: "No especificado",
-
+false: "false"
 
     },
   },

--- a/src/pages/cardtypes/CardTypes.tsx
+++ b/src/pages/cardtypes/CardTypes.tsx
@@ -389,8 +389,23 @@ const CardTypesTree = ({ rol }: CardTypesTreeProps) => {
   const renderCustomNodeElement = (rd3tProps: any) => {
     const { nodeDatum, toggleNode } = rd3tProps;
 
+    
+
     const isRoot = nodeDatum.__rd3t.depth === 0;
     const isPreclassifier = nodeDatum.nodeType === "preclassifier";
+
+
+    const getCollapsedState = (nodeId: string): boolean => {
+      const storedState = localStorage.getItem(`node_${nodeId}_collapsed`);
+      return storedState === "true"; // Convertir a booleano
+    };
+    
+    const setCollapsedState = (nodeId: string, isCollapsed: boolean) => {
+      localStorage.setItem(`node_${nodeId}_collapsed`, isCollapsed.toString());
+    };
+    
+    const isCollapsed = getCollapsedState(nodeDatum.id);
+  nodeDatum.__rd3t.collapsed = isCollapsed;
 
     const getStatusColor = (status: string | undefined) => {
       switch (status) {
@@ -430,6 +445,10 @@ const CardTypesTree = ({ rol }: CardTypesTreeProps) => {
     const handleLeftClick = (e: React.MouseEvent<SVGGElement>) => {
       e.stopPropagation();
       handleShowDetails(nodeDatum);
+
+      const newCollapsedState = !nodeDatum.__rd3t.collapsed;
+    setCollapsedState(nodeDatum.id, newCollapsedState);
+
       toggleNode();
     };
 

--- a/src/pages/cardtypes/CardTypes.tsx
+++ b/src/pages/cardtypes/CardTypes.tsx
@@ -396,8 +396,9 @@ const CardTypesTree = ({ rol }: CardTypesTreeProps) => {
 
 
     const getCollapsedState = (nodeId: string): boolean => {
-      const storedState = localStorage.getItem(`node_${nodeId}_collapsed`);
-      return storedState === "true"; // Convertir a booleano
+      const storedState:string | null = (localStorage.getItem(`node_${nodeId}_collapsed`)) ;
+      const booleanState: boolean = JSON.parse(storedState ?? Strings.false); // Parse the state
+      return booleanState;  
     };
     
     const setCollapsedState = (nodeId: string, isCollapsed: boolean) => {
@@ -582,8 +583,8 @@ const CardTypesTree = ({ rol }: CardTypesTreeProps) => {
           <Dropdown
             menu={{ items: rootMenu }}
             trigger={["contextMenu"]}
-            open={rootMenuVisible} // Controla la visibilidad con el estado
-            onOpenChange={(open) => setRootMenuVisible(open)} // Sincroniza el estado
+            open={rootMenuVisible} 
+            onOpenChange={(open) => setRootMenuVisible(open)} 
           >
             <circle
               r={22}

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -561,7 +561,7 @@ static preclassifierDetailsCode = "preclassifierDetailsCode";
 static preclassifierDetailsDescription = "preclassifierDetailsDescription";
 static preclassifierDetailsStatus = "preclassifierDetailsStatus";
 static notSpecified = "notSpecified";
-
+static false = "false"
 
 }
 


### PR DESCRIPTION
### Feature / Bug Description
- Keep  the nodes collapsed acording to the interaction of the user
- Set a color fo the "leaf nodes" on the Levels tree

### Solution
- Use the local storage to set the collapse property of each node.
- Vlidate the leaf nodes and set a new color.

### Notes
- I assigned this ticket to myself to cover the changes from the last review associated with KAN 43.

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-68)

### Screenshots / Screencasts

![image](https://github.com/user-attachments/assets/32ac8907-354d-4741-ab52-a5cdb19e682e)
