### PR TITLE
KAN-26 Generate a PDF in the card detail

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "antd": "^5.21.4",
         "env-cmd": "^10.1.0",
         "firebase": "^10.14.1",
+        "html2canvas": "^1.4.1",
         "i18next": "^24.2.1",
         "i18next-browser-languagedetector": "^8.0.2",
+        "jspdf": "^2.5.2",
         "moment": "^2.30.1",
         "react": "^18.3.1",
         "react-d3-tree": "^3.6.2",
@@ -27,6 +29,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@types/html2canvas": "^0.5.35",
         "@types/node": "^22.7.6",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -2313,6 +2316,26 @@
       "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
       "dev": true
     },
+    "node_modules/@types/html2canvas": {
+      "version": "0.5.35",
+      "resolved": "https://registry.npmjs.org/@types/html2canvas/-/html2canvas-0.5.35.tgz",
+      "integrity": "sha512-1A2dtWZbOIZ+rUK8jmAx1We/EiNV+5vScpphU3AF14Vby6COIazi/9StosrvlVCqlQegRhsEgZf7QYOuWbwuuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jquery": "*"
+      }
+    },
+    "node_modules/@types/jquery": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.32.tgz",
+      "integrity": "sha512-b9Xbf4CkMqS02YH8zACqN1xzdxc3cO735Qe5AbSUFmyOiaWAbcpqh9Wna+Uk0vgACvoQHpWDg2rGdHkYPLmCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sizzle": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "22.7.6",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.6.tgz",
@@ -2326,6 +2349,13 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.13.tgz",
       "integrity": "sha512-hCZTSvwbzWGvhqxp/RqVqwU999pBf2vp7hzIjiYOsl8wqOmUxkQ6ddw1cV3l8811+kdUFus/q4d1Y3E3SyEifA==",
       "devOptional": true
+    },
+    "node_modules/@types/raf": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/raf/-/raf-3.4.3.tgz",
+      "integrity": "sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.11",
@@ -2345,6 +2375,13 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/sizzle": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.9.tgz",
+      "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
@@ -2733,6 +2770,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/atob": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
+      "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "atob": "bin/atob.js"
+      },
+      "engines": {
+        "node": ">= 4.5.0"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.20",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.20.tgz",
@@ -2775,6 +2824,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2841,6 +2899,18 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2878,6 +2948,33 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
+    },
+    "node_modules/canvg": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/canvg/-/canvg-3.0.10.tgz",
+      "integrity": "sha512-qwR2FRNO9NlzTeKIPIKpnTY6fqwuYSequ8Ru8c0YkYU7U0oW+hLUvWadLvAu1Rl72OMNiFhoLu4f8eUjQ7l/+Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "@types/raf": "^3.4.0",
+        "core-js": "^3.8.3",
+        "raf": "^3.4.1",
+        "regenerator-runtime": "^0.13.7",
+        "rgbcolor": "^1.0.1",
+        "stackblur-canvas": "^2.0.0",
+        "svg-pathdata": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/canvg/node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/chain-function": {
       "version": "1.0.1",
@@ -3018,6 +3115,18 @@
         "toggle-selection": "^1.0.6"
       }
     },
+    "node_modules/core-js": {
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.40.0.tgz",
+      "integrity": "sha512-7vsMc/Lty6AGnn7uFpYT56QesI5D2Y/UkgKounk87OP9Z2H9Z8kj6jzcSGAxFmUtDOS0ntK6lbQz+Nsa0Jj6mQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -3029,6 +3138,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-line-break": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/css-line-break/-/css-line-break-2.1.0.tgz",
+      "integrity": "sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/cssesc": {
@@ -3316,6 +3434,13 @@
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
       }
+    },
+    "node_modules/dompurify": {
+      "version": "2.5.8",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
+      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -3766,6 +3891,12 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -4056,6 +4187,19 @@
         "void-elements": "3.1.0"
       }
     },
+    "node_modules/html2canvas": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
+      "integrity": "sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==",
+      "license": "MIT",
+      "dependencies": {
+        "css-line-break": "^2.1.0",
+        "text-segmentation": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/http-parser-js": {
       "version": "0.5.8",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.8.tgz",
@@ -4342,6 +4486,24 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jspdf": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
+      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2",
+        "atob": "^2.1.2",
+        "btoa": "^1.2.1",
+        "fflate": "^0.8.1"
+      },
+      "optionalDependencies": {
+        "canvg": "^3.0.6",
+        "core-js": "^3.6.0",
+        "dompurify": "^2.5.4",
+        "html2canvas": "^1.0.0-rc.5"
       }
     },
     "node_modules/keyv": {
@@ -4710,6 +4872,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/performance-now": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -4976,6 +5145,16 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "performance-now": "^2.1.0"
+      }
     },
     "node_modules/rc-cascader": {
       "version": "3.28.2",
@@ -5871,6 +6050,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rgbcolor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rgbcolor/-/rgbcolor-1.0.1.tgz",
+      "integrity": "sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==",
+      "license": "MIT OR SEE LICENSE IN FEEL-FREE.md",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8.15"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6041,6 +6230,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackblur-canvas": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/stackblur-canvas/-/stackblur-canvas-2.7.0.tgz",
+      "integrity": "sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/string-convert": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-convert/-/string-convert-0.2.1.tgz",
@@ -6181,6 +6380,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-pathdata": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/svg-pathdata/-/svg-pathdata-6.0.3.tgz",
+      "integrity": "sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "3.4.14",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.14.tgz",
@@ -6216,6 +6425,15 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/text-segmentation": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/text-segmentation/-/text-segmentation-1.0.3.tgz",
+      "integrity": "sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "utrie": "^1.0.2"
       }
     },
     "node_modules/text-table": {
@@ -6420,6 +6638,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/utrie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/utrie/-/utrie-1.0.2.tgz",
+      "integrity": "sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-arraybuffer": "^1.0.2"
+      }
     },
     "node_modules/uuid": {
       "version": "10.0.0",

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "antd": "^5.21.4",
     "env-cmd": "^10.1.0",
     "firebase": "^10.14.1",
+    "html2canvas": "^1.4.1",
     "i18next": "^24.2.1",
     "i18next-browser-languagedetector": "^8.0.2",
+    "jspdf": "^2.5.2",
     "moment": "^2.30.1",
     "react": "^18.3.1",
     "react-d3-tree": "^3.6.2",
@@ -28,6 +30,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@types/html2canvas": "^0.5.35",
     "@types/node": "^22.7.6",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -200,7 +200,7 @@ const resources = {
       // Tags re-design
       tagsOf: "Tags of",
       filters: "Filters",
-      status: "Status ",
+      status: "Status: ",
       dueDate: "Due date: ",
       cardType: "Tag type: ",
       problemType: "Problem type: ",
@@ -572,7 +572,13 @@ preclassifierDetailsCode: "Code",
 preclassifierDetailsDescription: "Description",
 preclassifierDetailsStatus: "Status",
 notSpecified: "Not Specified",
-false: "false"
+false: "false",
+
+//PDF
+tagDetails : "Tag details",
+problemDetails: "Problem details",
+sharePDF: "Share PDF",
+namePDF: "Tag details.pdf"
 
     },
   },
@@ -830,7 +836,7 @@ false: "false"
       // Tags re-design
       tagsOf: "Etiquetas de",
       filters: "Filtros",
-      status: "Estado ",
+      status: "Estado: ",
       dueDate: "Fecha de vencimiento: ",
       cardType: "Tipo de etiqueta: ",
       problemType: "Tipo de problema: ",
@@ -1202,7 +1208,13 @@ preclassifierDetailsCode: "Código",
 preclassifierDetailsDescription: "Descripción",
 preclassifierDetailsStatus: "Estado",
 notSpecified: "No especificado",
-false: "false"
+false: "false",
+
+//PDF 
+tagDetails : "Detalles de la tarjeta",
+problemDetails: "Detalles del problema",
+sharePDF: "Compartir PDF",
+namePDF: "Detalles de la tarjeta.pdf"
 
     },
   },

--- a/src/pages/carddetails/CardDetails.tsx
+++ b/src/pages/carddetails/CardDetails.tsx
@@ -21,6 +21,9 @@ import NoteCollapseV2 from "./components/NoteCollapseV2";
 import DefinitiveSolutionCollapseV2 from "./components/DefinitiveSolutionCollapseV2";
 import PageTitleTag from "../../components/PageTitleTag";
 import { Divider, Typography } from "antd";
+import PdfContent from "./components/PDFContent";
+import ExportPdfButton from "./components/ButtonPDF";
+
 
 const { Text } = Typography;
 
@@ -103,7 +106,14 @@ const CardDetails = () => {
           <PageTitleTag mainText={Strings.tagDetailsOf} subText={cardName} />
         </div>
 
+        <div className="ms-auto my-5 mx-12">
+          <ExportPdfButton targetId="pdf-content" filename={Strings.namePDF} />
+        </div>
+        <br />
+
         <div className="flex flex-col overflow-y-auto overflow-x-clipb gap-2">
+
+
           {data ? (
             <InfoCollapseV2
               data={data}
@@ -129,7 +139,7 @@ const CardDetails = () => {
             <LoadingCard />
           )}
 
-          <Divider style={{ borderColor: "#808080"}}>
+          <Divider style={{ borderColor: "#808080" }}>
             <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
               {Strings.changeLogDivider}
             </Text>
@@ -138,6 +148,15 @@ const CardDetails = () => {
           <div className="flex flex-col items-center m-3">
             {!isLoading ? <NoteCollapseV2 data={notes} /> : <LoadingCard />}
           </div>
+
+          <div className="App">
+            <div style={{ opacity: 0 }}>
+              <div id="pdf-content">
+                <PdfContent />
+              </div>
+            </div>
+          </div>
+
         </div>
       </div>
     </>

--- a/src/pages/carddetails/components/ButtonPDF.tsx
+++ b/src/pages/carddetails/components/ButtonPDF.tsx
@@ -1,0 +1,39 @@
+import React from "react";
+import html2canvas from "html2canvas";
+import jsPDF from "jspdf";
+import AnatomyButton from "../../../components/AnatomyButton";
+import Strings from "../../../utils/localizations/Strings";
+
+interface ExportPdfButtonProps {
+  targetId: string; // ID of the element you want to convert to PDF
+  filename?: string; // Optional name for the PDF file
+}
+
+const ExportPdfButton: React.FC<ExportPdfButtonProps> = ({ targetId, filename = "document.pdf" }) => {
+  const exportPDF = (): void => {
+    const input = document.getElementById(targetId);
+    if (input) {
+      html2canvas(input, { logging: true, useCORS: true }).then((canvas) => {
+        const imgWidth = 208;
+        const imgHeight = (canvas.height * imgWidth) / canvas.width;
+        const imgData = canvas.toDataURL("image/png");
+        const pdf = new jsPDF("p", "mm", "a4");
+        pdf.addImage(imgData, "PNG", 0, 0, imgWidth, imgHeight);
+        pdf.save(filename);
+      });
+    } else {
+      console.error(`Element with id '${targetId}' not found`);
+
+    }
+  };
+
+  return <AnatomyButton
+    title={Strings.sharePDF}
+    onClick={exportPDF}
+    type="default"
+    size="large"
+  />
+
+};
+
+export default ExportPdfButton;

--- a/src/pages/carddetails/components/PDFContent.tsx
+++ b/src/pages/carddetails/components/PDFContent.tsx
@@ -1,0 +1,150 @@
+import { useEffect, useState } from "react";
+import Strings from "../../../utils/localizations/Strings";
+import { useLocation, useNavigate } from "react-router-dom";
+import {
+  useGetCardDetailsMutation,
+  useGetCardNotesMutation,
+} from "../../../services/cardService";
+import { CardDetailsInterface } from "../../../data/card/card";
+import { UnauthorizedRoute } from "../../../utils/Routes";
+import { useAppDispatch, useAppSelector } from "../../../core/store";
+import {
+  resetCardUpdatedIndicator,
+  selectCardUpdatedIndicator,
+  setSiteId,
+} from "../../../core/genericReducer";
+import { Note } from "../../../data/note";
+import { Card, Col, Row } from "antd";
+import NoteCollapseV2 from "./NoteCollapseV2";
+import { Divider, Typography } from "antd";
+import PDFInfo from "./PDFInfo";
+import PDFSolution from "./PDFSolution";
+import PDFDefinitive from "./PDFDefinitive";
+
+const { Text } = Typography;
+
+const PdfContent = () => {
+  const [getCardDetails] = useGetCardDetailsMutation();
+  const [getNotes] = useGetCardNotesMutation();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [data, setData] = useState<CardDetailsInterface | null>(null);
+  const [notes, setNotes] = useState<Note[]>([]);
+  const dispatch = useAppDispatch();
+  const cardId = location?.state?.cardId || Strings.empty;
+  const isCardUpdated = useAppSelector(selectCardUpdatedIndicator);
+  const [isLoading, setLoading] = useState(false);
+
+  const storedCompanyInfo = JSON.parse(sessionStorage.getItem("companyInfo") || "{}");
+ 
+
+  useEffect(() => {
+    if (isCardUpdated) {
+      handleGetCards();
+      dispatch(resetCardUpdatedIndicator());
+    }
+  }, [isCardUpdated, dispatch]);
+
+  const handleGetCards = async () => {
+    if (!location.state) {
+      navigate(UnauthorizedRoute);
+      return;
+    }
+    setLoading(true);
+    const [responseData, responseNotes] = await Promise.all([
+      getCardDetails(cardId).unwrap(),
+      getNotes(cardId).unwrap(),
+    ]);
+    setData(responseData);
+    setNotes(responseNotes);
+    dispatch(setSiteId(responseData.card.siteId));
+    setLoading(false);
+  };
+
+  useEffect(() => {
+    handleGetCards();
+  }, []);
+
+  return (
+
+    <div className="flex flex-col px-4 mx-10 my-10">
+      <div className="mb-18">
+        <div style={{ marginBottom: '50px' }}></div>
+        <Row align="middle" style={{ width: '100%' }}>
+
+          {/* Left column with the company information */}
+          <Col
+            span={18}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              justifyContent: 'center',
+              alignItems: 'center',
+              textAlign: 'center',
+              marginBottom: '16px',
+            }}
+          >
+            <h1 style={{ fontSize: '35px', fontWeight: 'bold' }}>
+              {storedCompanyInfo.companyName || 'Empresa Desconocida'}
+            </h1>
+            <span style={{ fontSize: '20px', marginBottom: '8px' }}>
+              {storedCompanyInfo.companyAddress || 'Dirección desconocida'}
+            </span>
+            <span style={{ fontSize: '20px' }}>
+              {storedCompanyInfo.companyPhone || 'Teléfono desconocido'}
+            </span>
+          </Col>
+
+          {/* Right column with the logo of the company */}
+          <Col span={5} style={{ textAlign: 'right' }}>
+            <img
+              src={storedCompanyInfo.companyLogo || 'LogoDesconocido.png'}
+              alt="Logo de la empresa"
+              style={{ maxWidth: '150px', maxHeight: '150px' }}
+            />
+          </Col>
+        </Row>
+      </div>
+
+      <div>
+        {data ? (
+          <>
+            <div className="mb-18">
+              <PDFInfo data={data} />
+            </div>
+            <div className="mb-18">
+              <PDFSolution data={data} />
+            </div>
+
+            <div className="mb-18">
+              <PDFDefinitive data={data} />
+            </div>
+
+
+          </>
+        ) : (
+          <LoadingCard />
+        )}
+
+        <Divider style={{ borderColor: "#808080" }}>
+          <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
+            {Strings.changeLogDivider}
+          </Text>
+        </Divider>
+
+        <div className="flex flex-col items-center w-full m-3">
+          {!isLoading ? <NoteCollapseV2 data={notes} /> : <LoadingCard />}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+const LoadingCard = () => (
+  <Card
+    className="h-full bg-gray-100 rounded-xl shadow-md w-full"
+    loading={true}
+  />
+);
+
+export default PdfContent;

--- a/src/pages/carddetails/components/PDFDefinitive.tsx
+++ b/src/pages/carddetails/components/PDFDefinitive.tsx
@@ -1,0 +1,114 @@
+import Strings from "../../../utils/localizations/Strings";
+import { CardDetailsInterface } from "../../../data/card/card";
+import {
+  formatDate,
+  getDaysBetween,
+} from "../../../utils/Extensions";
+import { Divider, Typography } from "antd";
+
+
+import { Row, Col } from "antd";
+const { Text } = Typography;
+
+
+interface CardProps {
+  data: CardDetailsInterface;
+}
+
+const PDFDefinitive = ({ data }: CardProps) => {
+  const { card } = data;
+
+  return (
+    <div className="grid grid-rows-5 gap-y-4 gap-x-8 sm:grid-rows-none sm:gap-4 sm:px-4">
+
+
+      <Divider orientation="left" style={{ borderColor: "#808080" }}>
+        <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
+          {Strings.definitiveSolutionDivider}
+        </Text>
+      </Divider>
+
+
+
+
+      <Row gutter={15}>
+
+        <Col span={12}>
+
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagDate}
+            </span>
+            <p className="text-xl md:text-xl">
+              {formatDate(card.cardDefinitiveSolutionDate) || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={12}>
+
+
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagDays}
+            </span>
+            <p className="text-xl md:text-xl">
+              {getDaysBetween(card.createdAt, card.cardDefinitiveSolutionDate) ||
+                Strings.ceroDays}
+            </p>
+          </div>
+
+        </Col>
+
+      </Row>
+
+
+      <Row gutter={15}>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.appDefinitiveUser}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.userAppDefinitiveSolutionName || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.definitiveUser}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.userDefinitiveSolutionName || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.definitiveSolutionApplied}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.commentsAtCardDefinitiveSolution || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+      </Row>
+
+    </div>
+  );
+};
+
+export default PDFDefinitive;

--- a/src/pages/carddetails/components/PDFInfo.tsx
+++ b/src/pages/carddetails/components/PDFInfo.tsx
@@ -1,0 +1,334 @@
+import { Form } from "antd";
+import {
+  formatDate,
+  getCardStatusAndText,
+  getDaysSince,
+} from "../../../utils/Extensions";
+import Strings from "../../../utils/localizations/Strings";
+import { CardDetailsInterface } from "../../../data/card/card";
+import { useState } from "react";
+import UpdatePriorityForm from "./UpdatePriorityForm";
+import {
+  useUpdateCardMechanicMutation,
+  useUpdateCardPriorityMutation,
+} from "../../../services/cardService";
+import {
+  UpdateCardMechanic,
+  UpdateCardPriority,
+} from "../../../data/card/card.request";
+import { useAppDispatch, useAppSelector } from "../../../core/store";
+import { selectCurrentUser } from "../../../core/authReducer";
+import {
+  handleErrorNotification,
+  handleSucccessNotification,
+  NotificationSuccess,
+} from "../../../utils/Notifications";
+import { setCardUpdatedIndicator } from "../../../core/genericReducer";
+import UpdateMechanicForm from "./UpdateMechanicForm";
+import { Divider, Typography } from "antd";
+
+import { Row, Col } from "antd";
+
+
+import { theme } from "antd";
+import CustomTagV2 from "../../../components/CustomTagV2";
+
+
+const { useToken } = theme;
+const { Text } = Typography;
+
+
+interface CardProps {
+  data: CardDetailsInterface;
+}
+
+const PDFInfo = ({ data }: CardProps) => {
+  const [modalIsLoading, setModalLoading] = useState(false);
+  const [modalIsOpen, setModalOpen] = useState(false);
+  const [modalType, setModalType] = useState(Strings.empty);
+  const currentUser = useAppSelector(selectCurrentUser);
+  const [updateCardPriority] = useUpdateCardPriorityMutation();
+  const [updateCardMechanic] = useUpdateCardMechanicMutation();
+  const dispatch = useAppDispatch();
+  const { token } = useToken();
+  const primaryColor = token.colorPrimary;
+
+  const { card } = data;
+  const cardStatus = getCardStatusAndText(
+    card.status,
+    card.cardDueDate,
+    card.cardDefinitiveSolutionDate,
+    card.cardCreationDate
+  );
+
+
+  const handleOnOpenModal = (modalType: string) => {
+    setModalOpen(true);
+    setModalType(modalType);
+  };
+  const handleOnCancelButton = () => {
+    if (!modalIsLoading) {
+      setModalOpen(false);
+    }
+  };
+
+  const selectFormByModalType = (modalType: string) => {
+    if (modalType === Strings.priority) {
+      return UpdatePriorityForm;
+    } else {
+      return UpdateMechanicForm;
+    }
+  };
+
+  const selecTitleByModalType = (modalType: string) => {
+    if (modalType === Strings.priority) {
+      return Strings.updatePriority;
+    } else {
+      return Strings.updateMechanic;
+    }
+  };
+
+  const handleOnFormUpdateFinish = async (values: any) => {
+    try {
+      setModalLoading(true);
+      if (modalType === Strings.priority) {
+        await updateCardPriority(
+          new UpdateCardPriority(
+            Number(card.id),
+            Number(values.priorityId),
+            Number(currentUser.userId)
+          )
+        ).unwrap();
+      } else {
+        await updateCardMechanic(
+          new UpdateCardMechanic(
+            Number(card.id),
+            Number(values.mechanicId),
+            Number(currentUser.userId)
+          )
+        ).unwrap();
+      }
+      setModalOpen(false);
+      dispatch(setCardUpdatedIndicator());
+      handleSucccessNotification(NotificationSuccess.UPDATE);
+    } catch (error) {
+      handleErrorNotification(error);
+    } finally {
+      setModalLoading(false);
+    }
+  };
+
+  return (
+    <>
+
+
+      <Divider orientation="left" style={{ borderColor: "#808080" }}>
+        <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
+          {Strings.tagDetails}
+        </Text>
+      </Divider>
+
+
+      <div className="grid grid-rows-5 gap-y-6 gap-x-8 sm:grid-rows-none sm:gap-4 sm:px-4">
+
+        <div className="mb-18">
+          <Row gutter={15} className="mb-3">
+
+            <Col span={8}>
+              <div className="flex items-center gap-5">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.tagNumber}
+                </span>
+                <p className="text-xl md:text-xl">
+                  {card.siteCardId || Strings.NA}
+                </p>
+              </div>
+            </Col>
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.cardType}
+                </span>
+                <p
+                  className="font-semibold text-xl md:text-xl"
+                  style={{ color: `#${card.cardTypeColor}` }}
+                >
+                  {card.cardTypeName}
+                </p>
+              </div>
+            </Col>
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.status}
+                </span>
+                <CustomTagV2 className="w-min text-xl" color={cardStatus.status}>
+                  <span className="font-medium">{cardStatus.text}</span>
+                </CustomTagV2>
+              </div>
+            </Col>
+
+          </Row>
+
+
+          <Row gutter={15} className="mb-3">
+
+            <Col span={8}>
+              <div className="flex flex-col items-start">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.creationDate}
+                </span>
+                <p className="text-left px-1 text-xl md:text-xl">
+                  {formatDate(card.createdAt) || Strings.NA}
+                </p>
+              </div>
+            </Col>
+
+            <Col span={8}>
+              <div className="flex flex-wrap items-center gap-4 md:gap-8">
+                <div className="flex items-center gap-1">
+                  <p className="font-semibold text-xl md:text-xl">
+                    {Strings.createdBy}
+                  </p>
+                  <p className="text-xl md:text-xl">
+                    {card.creatorName || Strings.NA}
+                  </p>
+                </div>
+              </div>
+            </Col>
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.daysSinceCreation}
+                </span>
+                <p className="text-center font-semibold text-xl md:text-xl">
+                  {getDaysSince(card.createdAt) || Strings.cero}
+                </p>
+              </div>
+            </Col>
+
+
+          </Row>
+
+
+
+          <Row gutter={15} className="mb-3">
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.dueDate}
+                </span>
+                <p className="text-left px-1 text-xl md:text-xl">
+                  {card.cardDueDate || Strings.NA}
+                </p>
+              </div>
+            </Col>
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <p className="font-semibold text-xl md:text-xl">
+                  {Strings.tagPriority}
+                </p>
+                <p
+                  onClick={() => handleOnOpenModal(Strings.priority)}
+                  className="text-xl md:text-xl"
+                >
+                  {card.priorityCode
+                    ? `${card.priorityCode} - ${card.priorityDescription}`
+                    : Strings.NA}
+                </p>
+              </div>
+            </Col>
+
+
+            <Col span={8}>
+              <div className="flex items-center gap-1">
+                <span className="font-semibold text-xl md:text-xl">
+                  {Strings.dateStatus}
+                </span>
+                <span
+                  className={`text-xl font-bold  ${cardStatus.dateStatus === Strings.expired
+                    ? "text-red-500"
+                    : "text-green-500"
+                    }`}
+                >
+                  {cardStatus.dateStatus}
+                </span>
+
+              </div>
+            </Col>
+
+          </Row>
+
+        </div>
+        <Divider orientation="left" style={{ borderColor: "#808080" }}>
+          <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
+            {Strings.problemDetails}
+          </Text>
+        </Divider>
+
+
+        <Row gutter={15} className="mb-3">
+          <Col span={12}>
+            <div className="flex flex-col">
+              <span className="font-semibold text-xl md:text-xl">
+                {Strings.problemType}
+              </span>
+              <p className="text-left px-1 text-xl md:text-xl">
+                {card.preclassifierCode
+                  ? `${card.preclassifierCode} - ${card.preclassifierDescription}`
+                  : Strings.NA}
+              </p>
+            </div>
+          </Col>
+
+          <Col span={12}>
+            <div className="flex flex-col">
+              <span className="font-semibold text-xl md:text-xl">
+                {Strings.location}
+              </span>
+              <p className="text-left px-1 text-xl md:text-xl">
+                {card.cardLocation || Strings.NA}
+              </p>
+            </div>
+          </Col>
+        </Row>
+
+        <Row gutter={15} className="mb-3">
+          <Col span={12}>
+            <div className="flex items-center gap-1">
+              <p className="font-semibold text-xl md:text-xl">
+                {Strings.tagMechanic}
+              </p>
+              <p className="text-left px-1 text-xl md:text-xl">
+                {card.mechanicName || Strings.NA}
+              </p>
+            </div>
+          </Col>
+
+          <Col span={12}>
+
+            {/* Anomaly detected */}
+            <div className="flex items-center gap-1">
+              <p className="font-semibold text-xl md:text-xl">
+                {Strings.anomalyDetected}
+              </p>
+              <p className="text-xl md:text-xl">
+                {card.commentsAtCardCreation || Strings.NA}
+              </p>
+            </div>
+          </Col>
+        </Row>
+
+
+      </div>
+
+    </>
+  );
+};
+
+export default PDFInfo;

--- a/src/pages/carddetails/components/PDFSolution.tsx
+++ b/src/pages/carddetails/components/PDFSolution.tsx
@@ -1,0 +1,111 @@
+import Strings from "../../../utils/localizations/Strings";
+import { CardDetailsInterface } from "../../../data/card/card";
+import {
+  formatDate,
+  getDaysBetween,
+} from "../../../utils/Extensions";
+import { Divider, Typography } from "antd";
+
+import { Row, Col } from "antd";
+
+const { Text } = Typography;
+
+interface PDFSolutionProps {
+  data: CardDetailsInterface;
+}
+
+const PDFSolution: React.FC<PDFSolutionProps> = ({ data }) => {
+  const { card } = data;
+
+  return (
+
+    <div className="grid grid-rows-5 gap-y-4 gap-x-8 sm:grid-rows-none sm:gap-4 sm:px-4">
+
+      <Divider orientation="left" style={{ borderColor: "#808080" }}>
+        <Text style={{ fontSize: "24px", fontWeight: "bold" }}>
+          {Strings.provisionalSolution}
+        </Text>
+      </Divider>
+
+
+      <Row gutter={15}>
+
+        <Col span={12}>
+
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagDate}
+            </span>
+            <p className="text-xl md:text-xl">
+              {formatDate(card.cardProvisionalSolutionDate) || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={12}>
+
+          <div className="flex items-center gap-2">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagDays}
+            </span>
+            <p className="text-xl md:text-xl">
+              {getDaysBetween(card.createdAt, card.cardProvisionalSolutionDate) ||
+                Strings.ceroDays}
+            </p>
+          </div>
+
+        </Col>
+
+      </Row>
+
+
+      <Row gutter={15}>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.appProvisionalUser}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.userAppProvisionalSolutionName || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagProvisionalUser}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.userProvisionalSolutionName || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+        <Col span={8}>
+
+          <div className="flex flex-col">
+            <span className="font-semibold text-xl md:text-xl">
+              {Strings.tagProvisionalSoluitonApplied}
+            </span>
+            <p className="text-left px-1 text-xl md:text-xl">
+              {card.commentsAtCardProvisionalSolution || Strings.NA}
+            </p>
+          </div>
+
+        </Col>
+
+      </Row>
+
+
+    </div>
+  );
+};
+
+export default PDFSolution;

--- a/src/pages/company/components/CompanyCard.tsx
+++ b/src/pages/company/components/CompanyCard.tsx
@@ -20,7 +20,7 @@ const CompanyCard = ({ data }: CompanyCardProps) => {
     {
       key: "1",
       label: (
-        <ViewSitesButton companyId={data.id} companyName={data.name} />
+        <ViewSitesButton companyId={data.id} companyName={data.name} companyAddress={data.address} companyPhone={data.phone} companyLogo={data.logo}  />
       ),
     },
     {

--- a/src/pages/company/components/CompanyTable.tsx
+++ b/src/pages/company/components/CompanyTable.tsx
@@ -131,7 +131,8 @@ const CompanyTable = ({ data, isLoading }: CompaniesTableProps) => {
     showExpandColumn: false,
     expandedRowRender: (data: Company) => (
       <Space className="flex justify-end">
-        <ViewSitesButton companyId={data.id} companyName={data.name} />
+        <ViewSitesButton companyId={data.id} companyName={data.name} companyAddress={data.address} companyPhone={data.phone} companyLogo={data.logo}  />
+        
         <UpdateCompany data={data} />
       </Space>
     ),

--- a/src/pages/company/components/ViewSitesButton.tsx
+++ b/src/pages/company/components/ViewSitesButton.tsx
@@ -6,21 +6,25 @@ import { adminSites } from "../../routes/Routes";
 interface props {
   companyId: string;
   companyName: string;
+  companyAddress: string;
+  companyPhone: string;
+  companyLogo: string
 }
 
-const ViewSitesButton = ({ companyId, companyName }: props) => {
+const ViewSitesButton = ({ companyId, companyName, companyAddress,companyPhone,companyLogo }: props) => {
+
   const navigate = useNavigate();
 
-  const handleOnViewPriorities = (companyId: string, companyName: string) => {
+  const handleOnViewPriorities = (companyId: string, companyName: string, companyAddress:string, companyPhone: string, companyLogo:string ) => {
     navigate(adminSites.fullPath.replace(Strings.companyParam, companyId), {
-      state: { companyId, companyName },
-    });
+      state: { companyId, companyName, companyAddress,companyPhone, companyLogo},
+      });
   };
 
   return (
     <CustomButton
       type="action"
-      onClick={() => handleOnViewPriorities(companyId, companyName)}
+      onClick={() => handleOnViewPriorities(companyId, companyName, companyAddress,companyPhone, companyLogo)}
     >
       {Strings.viewSites}
     </CustomButton>

--- a/src/pages/site/Sites.tsx
+++ b/src/pages/site/Sites.tsx
@@ -61,6 +61,19 @@ const Sites = ({ rol }: SitesProps) => {
       navigate(UnauthorizedRoute);
       return;
     }
+
+
+    const companyInfo = {
+      companyId: location.state.companyId,
+      companyName: location.state.companyName,
+      companyAddress: location.state.companyAddress,
+      companyPhone: location.state.companyPhone,
+      companyLogo: location.state.companyLogo,
+    };
+
+    sessionStorage.setItem("companyInfo", JSON.stringify(companyInfo));
+
+
     const user = getSessionUser() as User;
     setLoading(true);
     var response;

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -563,6 +563,12 @@ static preclassifierDetailsStatus = "preclassifierDetailsStatus";
 static notSpecified = "notSpecified";
 static false = "false"
 
+ //PDF 
+ static tagDetails = "tagDetails"
+ static problemDetails= "problemDetails"
+ static sharePDF= "sharePDF"
+ static namePDF = "namePDF"
+
 }
 
 const Strings = new Proxy(StringsBase, {


### PR DESCRIPTION
### Feature / Bug Description  
The user now has the ability to download a PDF with the details of the cards.  

### Solution  
To achieve this:  
1. Installed two dependencies: **"html2canvas"** and **"jspdf"**.  
2. Created new components such as **PDFInfo**, **PDFSolution**, and **PDFDefinitive**, where only the design of the information to be displayed changes.  
3. Modified some details of the companies to display them as headers in the PDF.  
4. Created **PDFContent**, which consolidates all the new information and is the component downloaded as a PDF.  
5. Created **ButtonPDF**, which provides the ability to download the button.  

### Notes  
No  

### Tickets  
[[TICKET](https://one-sm.atlassian.net/browse/KAN-26)](https://one-sm.atlassian.net/browse/KAN-26)  

### Screenshots / Screencasts  
![image](https://github.com/user-attachments/assets/2769666e-4ae9-481a-a9d7-24b67dfbf873)