### PR TITLE
KAN-48 Login update

### DIFF
--- a/src/components/AnatomyButton.tsx
+++ b/src/components/AnatomyButton.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { Button, theme } from 'antd';
 
-
 const { useToken } = theme;
-
 
 interface AnatomyButtonProps {
   title: string;
@@ -11,8 +9,9 @@ interface AnatomyButtonProps {
   type?: 'default' | 'danger' | 'outline' | 'text';
   size?: 'small' | 'middle' | 'large';
   className?: string;
+  loading?: boolean;
+  htmlType?: 'button' | 'submit' | 'reset';
 }
-
 
 const AnatomyButton: React.FC<AnatomyButtonProps> = ({
   title,
@@ -20,16 +19,16 @@ const AnatomyButton: React.FC<AnatomyButtonProps> = ({
   type = 'default',
   size = 'middle',
   className = '',
+  loading = false, // By default, it will be false
+  htmlType = 'button', // By default, it will be "button"
 }) => {
   // Get the primary color of the global theme
   const { token } = useToken();
   const primaryColor = token.colorPrimary;
 
-
   // Set the button type and corresponding styles
   const antType =
     type === 'danger' ? 'primary' : type === 'outline' ? 'default' : type;
-
 
   const buttonStyles: React.CSSProperties = {
     borderRadius: '9999px', // This ensures that the button has rounded edges
@@ -55,7 +54,6 @@ const AnatomyButton: React.FC<AnatomyButtonProps> = ({
     }),
   };
 
-
   return (
     <Button
       type={antType}
@@ -63,11 +61,12 @@ const AnatomyButton: React.FC<AnatomyButtonProps> = ({
       className={className}
       onClick={onClick}
       style={buttonStyles}
+      loading={loading} // Ant Design loading
+      htmlType={htmlType} // Ant Design htmlType
     >
       {title}
     </Button>
   );
 };
-
 
 export default AnatomyButton;

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -2,6 +2,8 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 
+
+//ENGLISH
 const resources = {
   en: {
     translation: {
@@ -631,8 +633,13 @@ false: "false",
 tagDetails : "Tag details",
 problemDetails: "Problem details",
 sharePDF: "Share PDF",
-namePDF: "Tag details.pdf"
+namePDF: "Tag details.pdf",
 
+//Login Refactor
+logImgDesc: "Log In Image",
+enSub: "One Smart Mate"
+
+//SPANISH
     },
   },
   es: {
@@ -1269,7 +1276,10 @@ false: "false",
 tagDetails : "Detalles de la tarjeta",
 problemDetails: "Detalles del problema",
 sharePDF: "Compartir PDF",
-namePDF: "Detalles de la tarjeta.pdf"
+namePDF: "Detalles de la tarjeta.pdf",
+
+logImgDesc: "Imagen del Log In",
+enSub: "One Smart Mate"
 
     },
   },

--- a/src/pages/auth/LoginV2.tsx
+++ b/src/pages/auth/LoginV2.tsx
@@ -1,5 +1,5 @@
-import { Form, Button, Input, Layout, Card } from "antd";
-import React, { useEffect } from "react";
+import { Form, Input, Layout, Card } from "antd";
+import React,{ useEffect} from "react";
 import { useLoginMutation } from "../../services/authService";
 import { LoginRequest } from "../../data/user/user.request";
 import { useAppDispatch } from "../../core/store";
@@ -20,14 +20,13 @@ import {
 } from "../../utils/Extensions";
 import Strings from "../../utils/localizations/Strings";
 import { ResetPasswordRoute } from "../../utils/Routes";
+import AnatomyButton from "../../components/AnatomyButton";
 
 const LoginPage = () => {
   const [isPasswordVisible, setPasswordVisible] = React.useState(false);
   const [login, { isLoading }] = useLoginMutation();
   const dispatch = useAppDispatch();
-  const [getSessionUser, setSessionUser] = useSessionStorage<User>(
-    Strings.empty
-  );
+  const [getSessionUser, setSessionUser] = useSessionStorage<User>(Strings.empty);
   const navigate = useNavigate();
 
   const handleUserSession = () => {
@@ -44,10 +43,7 @@ const LoginPage = () => {
     const rol = getUserRol(user);
     if (rol === UserRoles.IHSISADMIN) {
       navigate(getInitRoute(user));
-    } else if (
-      rol === UserRoles.LOCALSYSADMIN ||
-      rol === UserRoles.LOCALADMIN
-    ) {
+    } else if (rol === UserRoles.LOCALSYSADMIN || rol === UserRoles.LOCALADMIN) {
       navigate(getInitRoute(user), {
         state: {
           companyId: user.companyId,
@@ -68,9 +64,7 @@ const LoginPage = () => {
 
   const onFinish = async (values: any) => {
     try {
-      const data = await login(
-        new LoginRequest(values.email, values.password)
-      ).unwrap();
+      const data = await login(new LoginRequest(values.email, values.password)).unwrap();
       setSessionUser(data);
       dispatch(setCredentials({ ...data }));
       handleNavigation(data);
@@ -81,26 +75,33 @@ const LoginPage = () => {
 
   return (
     <Layout className="flex justify-center items-center min-h-screen">
-      <Card className="p-3 relative w-full sm:w-[600px] h-auto sm:h-[400px] rounded-2xl">
-        <div className="flex items-center space-x-4">
+      <Card className="p-6 relative sm:w-[600px] sm:h-[450px] rounded-2xl flex items-center">
+        <div className="flex w-full h-full items-center space-x-4">
           <img
-            className="w-[250px] o h-[350px]"
+            className="w-[250px] h-[350px] hidden sm:block object-cover rounded-xl"
             src="https://img.freepik.com/fotos-premium/trabajador-industria-hd-8k-fondo-pantalla-imagen-fotografica-stock_890746-39011.jpg"
-            alt="Descripción de la imagen"
+            alt={Strings.logImgDesc}
           />
 
-          {/* Content to the right of the image */}
-          <div className="flex-1">
+         
+          <div className="flex-1 py-4 flex flex-col h-full justify-between">
             <Meta
               title={
-                <h1 className="text-center text-3xl block font-semibold mb-4">
-                  {Strings.entrepriseName}
-                </h1>
+                <>
+                  <h1 className="text-center text-3xl block font-semibold">
+                    {Strings.entrepriseName}
+                  </h1>
+                  <span className="leading-tight text-center block font-semibold mb-4">
+                    {Strings.enSub}
+                  </span>
+                </>
               }
             />
+
             <div className="text-left">
               <p className="leading-tight">{Strings.loginText}</p>
             </div>
+
             <Form
               name="normal_login"
               className="mt-6"
@@ -109,10 +110,7 @@ const LoginPage = () => {
               validateTrigger="onSubmit"
             >
               <Form.Item name="email" rules={[{ validator: validateEmail }]}>
-                <Input
-                  size="large"
-                  placeholder={Strings.email}
-                />
+                <Input size="large" placeholder={Strings.email} />
               </Form.Item>
               <Form.Item
                 name="password"
@@ -130,26 +128,26 @@ const LoginPage = () => {
                 />
               </Form.Item>
               <div className="text-right mb-4">
-                <Link className=" font-semibold" to={ResetPasswordRoute}>
+                <Link className="font-semibold" to={ResetPasswordRoute}>
                   {Strings.forgotPassword}
                 </Link>
               </div>
-              <Form.Item className="text-center">
-                <Button
-                  loading={isLoading}
+
+              
+                <AnatomyButton
+                  title="Iniciar sesión"
+                  onClick={() => {}} 
+                  type="default"
+                  size="large"
                   className="px-12 py-4 text-lg mt-4 w-full rounded-full"
-                  type="primary"
+                  loading={isLoading}
                   htmlType="submit"
-                >
-                  {Strings.login}
-                </Button>
-              </Form.Item>
+                />
             </Form>
           </div>
         </div>
       </Card>
     </Layout>
-
   );
 };
 

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -569,6 +569,11 @@ static false = "false"
  static sharePDF= "sharePDF"
  static namePDF = "namePDF"
 
+
+ //Login 
+ static logImgDesc = "logImgDesc"
+ static enSub = "enSub"
+
 }
 
 const Strings = new Proxy(StringsBase, {


### PR DESCRIPTION
### Feature / Bug Description  
I updated the Log In with the corrections mentioned in the ticket.  

### Solution  

- The top and bottom margins now have the same measurement for both the image and the text. To achieve this for the image, `"py-6"` was added to the corresponding `div`, and for the text, it was necessary to remove the `Form.Item` tag.  

- The button was replaced with the `AnatomyButton`, adding two new properties to this component: `loading` and `htmlType`.  

- The subtitle **"One Smart Mate"** was added as requested.

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-48)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/08035284-a9f2-4ea9-b9c5-e2ece988edac)

