### PR TITLE
KAN - 75 Clone children levels in levels tree

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -6,6 +6,9 @@ import LanguageDetector from "i18next-browser-languagedetector";
 const resources = {
   en: {
     translation: {
+      errorCloningTheLevel: "Error cloning the tree: ",
+      errorGettingLevelId: "Error getting level id",
+      copy: "(copy)",
       associatedTags: "Associated Tags",
       commentsTag: "Comments:",
       noCommentsTag: "No comments",
@@ -650,6 +653,9 @@ const resources = {
   },
   es: {
     translation: {
+      errorCloningTheLevel: "Error al clonar el arbol: ",
+      errorGettingLevelId: "Error al obtener el id del nivel",
+      copy: "(copia)",
       associatedTags: "Tarjetas asociadas",
       commentsTag: "Comentarios:",
       noCommentsTag: "Sin comentarios",

--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -6,6 +6,7 @@ import LanguageDetector from "i18next-browser-languagedetector";
 const resources = {
   en: {
     translation: {
+      cloningLevelsMessage: "Cloning levels...",
       errorCloningTheLevel: "Error cloning the tree: ",
       errorGettingLevelId: "Error getting level id",
       copy: "(copy)",
@@ -653,6 +654,7 @@ const resources = {
   },
   es: {
     translation: {
+      cloningLevelsMessage: "Clonando niveles...",
       errorCloningTheLevel: "Error al clonar el arbol: ",
       errorGettingLevelId: "Error al obtener el id del nivel",
       copy: "(copia)",

--- a/src/pages/carddetails/components/UpdateMechanicForm.tsx
+++ b/src/pages/carddetails/components/UpdateMechanicForm.tsx
@@ -38,16 +38,17 @@ const UpdateMechanicForm = ({ form, cardId, cardName, card }: FormProps) => {
   const [siteUsers, setSiteUsers] = useState<UserTable[]>([]);
   const [, setLoading] = useState(false);
 
+
+  const fetchSiteUsers = async () => {
+    try {
+      const response = await getSiteUsers(siteId).unwrap();
+      setSiteUsers(response);
+    } catch (error) {
+      
+    }
+  };
   useEffect(() => {
     if (!siteId) return;
-    const fetchSiteUsers = async () => {
-      try {
-        const response = await getSiteUsers(siteId).unwrap();
-        setSiteUsers(response);
-      } catch (error) {
-        
-      }
-    };
     fetchSiteUsers();
   }, [siteId, getSiteUsers]);
 
@@ -65,7 +66,7 @@ const UpdateMechanicForm = ({ form, cardId, cardName, card }: FormProps) => {
     }
     setLoading(true);
     try {
-      const currentUserId = 1; 
+      const currentUserId = selectedUserId; 
       await updateCardMechanic({
         cardId: Number(finalCardId),
         mechanicId: Number(selectedUserId),

--- a/src/pages/carddetails/components/UpdateMechanicForm.tsx
+++ b/src/pages/carddetails/components/UpdateMechanicForm.tsx
@@ -3,17 +3,18 @@ import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import { useAppSelector } from "../../../core/store";
 import { selectSiteId } from "../../../core/genericReducer";
-import { useGetUsersByRoleMutation } from "../../../services/userService";
+import { useGetSiteUsersMutation } from "../../../services/userService";
 import { useSendCardAssignmentMutation } from "../../../services/mailService";
-import { Responsible } from "../../../data/user/user";
+import { useUpdateCardMechanicMutation } from "../../../services/cardService";
+import { UserTable } from "../../../data/user/user";
 import Strings from "../../../utils/localizations/Strings";
 import Constants from "../../../utils/Constants";
 
 interface FormProps {
   form: FormInstance;
-  cardId?: number;    
-  cardName?: string;  
-  card?: any;         
+  cardId?: number;
+  cardName?: string;
+  card?: any;
 }
 
 const UpdateMechanicForm = ({ form, cardId, cardName, card }: FormProps) => {
@@ -22,188 +23,76 @@ const UpdateMechanicForm = ({ form, cardId, cardName, card }: FormProps) => {
   const state = (location.state as { cardId?: number; cardName?: string; card?: any }) || {};
   const finalCardId = cardId !== undefined ? cardId : state.cardId;
   const finalCardName = cardName !== undefined ? cardName : state.cardName;
-  
+
   const cardFromState = card !== undefined ? card : (state.card || {});
-  
   const definitiveSolutionExists =
     cardFromState.userAppDefinitiveSolutionId != null &&
     cardFromState.userAppDefinitiveSolutionName != null &&
     String(cardFromState.userAppDefinitiveSolutionId).trim() !== "" &&
     cardFromState.userAppDefinitiveSolutionName.trim() !== "";
 
-  const [getUsersByRole] = useGetUsersByRoleMutation();
+  const [getSiteUsers] = useGetSiteUsersMutation();
   const [sendCardAssignment] = useSendCardAssignmentMutation();
+  const [updateCardMechanic] = useUpdateCardMechanicMutation();
 
-  const [ihSisAdmins, setIhSisAdmins] = useState<Responsible[]>([]);
-  const [mechanics, setMechanics] = useState<Responsible[]>([]);
-  const [localAdmins, setLocalAdmins] = useState<Responsible[]>([]);
-  const [localSisAdmins, setLocalSisAdmins] = useState<Responsible[]>([]);
-  const [operators, setOperators] = useState<Responsible[]>([]);
-  const [externalProviders, setExternalProviders] = useState<Responsible[]>([]);
-
-  const handleSelect = (roleName: string, value: number | undefined) => {
-    if (value) {
-      const allFields = [
-        Constants.ihSisAdmin + Constants.id,
-        Constants.mechanic + Constants.id,
-        Constants.localAdmin + Constants.id,
-        Constants.localSisAdmin + Constants.id,
-        Constants.operator + Constants.id,
-        Constants.externalProvider + Constants.id,
-      ];
-      const fieldsToClear = allFields.filter((f) => f !== roleName);
-      const objToClear: Record<string, undefined> = {};
-      fieldsToClear.forEach((field) => {
-        objToClear[field] = undefined;
-      });
-      form.setFieldsValue(objToClear);
-    }
-  };
-
-  const onFinish = async (values: any) => {
-    
-    
-    if (finalCardId === undefined || finalCardName === undefined || definitiveSolutionExists) {
-      return;
-    }
-    
-    const externalUserId = values[Constants.externalProvider + Constants.id];
-    if (externalUserId) {
-      try {
-        await sendCardAssignment({
-          userId: Number(externalUserId),
-          cardId: Number(finalCardId),
-          cardName: finalCardName,
-        }).unwrap();
-      } catch (error) {
-        throw error;
-      }
-    } else {
-      return;
-    }
-  };
+  const [siteUsers, setSiteUsers] = useState<UserTable[]>([]);
+  const [, setLoading] = useState(false);
 
   useEffect(() => {
     if (!siteId) return;
-
-    const fetchRolesData = async () => {
+    const fetchSiteUsers = async () => {
       try {
-        const [
-          respIH,
-          respMech,
-          respLocalAdm,
-          respLocalSis,
-          respOper,
-          respExtProv,
-        ] = await Promise.all([
-          getUsersByRole({ siteId, roleName: Constants.ihSisAdmin }).unwrap(),
-          getUsersByRole({ siteId, roleName: Constants.mechanic }).unwrap(),
-          getUsersByRole({ siteId, roleName: Constants.localAdmin }).unwrap(),
-          getUsersByRole({ siteId, roleName: Constants.localSisAdmin }).unwrap(),
-          getUsersByRole({ siteId, roleName: Constants.operator }).unwrap(),
-          getUsersByRole({ siteId, roleName: Constants.externalProvider }).unwrap(),
-        ]);
-
-        setIhSisAdmins(respIH);
-        setMechanics(respMech);
-        setLocalAdmins(respLocalAdm);
-        setLocalSisAdmins(respLocalSis);
-        setOperators(respOper);
-        setExternalProviders(respExtProv);
+        const response = await getSiteUsers(siteId).unwrap();
+        setSiteUsers(response);
       } catch (error) {
-        throw error;
+        
       }
     };
+    fetchSiteUsers();
+  }, [siteId, getSiteUsers]);
 
-    fetchRolesData();
-  }, [siteId, getUsersByRole]);
+  const onFinish = async (values: any) => {
+    const selectedUserId = values.mechanicId;
+    if (!selectedUserId) {
+      return;
+    }
+    if (!finalCardId || !finalCardName || definitiveSolutionExists) {
+      return;
+    }
+    const selectedUser = siteUsers.find((user) => user.id === selectedUserId);
+    if (!selectedUser) {
+      return;
+    }
+    setLoading(true);
+    try {
+      const currentUserId = 1; 
+      await updateCardMechanic({
+        cardId: Number(finalCardId),
+        mechanicId: Number(selectedUserId),
+        idOfUpdatedBy: currentUserId,
+      }).unwrap();
+      const isExternalProvider = selectedUser.roles.some(
+        (role) => role.name === Constants.externalProvider
+      );
+      if (isExternalProvider) {
+        await sendCardAssignment({
+          userId: Number(selectedUserId),
+          cardId: Number(finalCardId),
+          cardName: finalCardName,
+        }).unwrap();
+      }
+    } catch (error) {
+    } finally {
+      setLoading(false);
+    }
+  };
 
   return (
     <Form form={form} onFinish={onFinish}>
-      {/* IH_sis_admin */}
-      <Form.Item label={Constants.ihSisAdmin} name={Constants.ihSisAdmin + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.ihSisAdmin}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.ihSisAdmin + Constants.id, value)}
-        >
-          {ihSisAdmins.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
-              {user.name}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      {/* mechanic */}
-      <Form.Item label={Constants.mechanic} name={Constants.mechanic + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.mechanic}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.mechanic + Constants.id, value)}
-        >
-          {mechanics.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
-              {user.name}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      {/* local_admin */}
-      <Form.Item label={Constants.localAdmin} name={Constants.localAdmin + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.localAdmin}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.localAdmin + Constants.id, value)}
-        >
-          {localAdmins.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
-              {user.name}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      {/* local_sis_admin */}
-      <Form.Item label={Constants.localSisAdmin} name={Constants.localSisAdmin + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.localSisAdmin}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.localSisAdmin + Constants.id, value)}
-        >
-          {localSisAdmins.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
-              {user.name}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      {/* operator */}
-      <Form.Item label={Constants.operator} name={Constants.operator + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.operator}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.operator + Constants.id, value)}
-        >
-          {operators.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
-              {user.name}
-            </Select.Option>
-          ))}
-        </Select>
-      </Form.Item>
-
-      {/* external_provider */}
-      <Form.Item label={Constants.externalProvider} name={Constants.externalProvider + Constants.id}>
-        <Select
-          placeholder={`${Strings.selectRole} ${Constants.externalProvider}`}
-          allowClear
-          onChange={(value) => handleSelect(Constants.externalProvider + Constants.id, value)}
-        >
-          {externalProviders.map((user) => (
-            <Select.Option key={user.id} value={Number(user.id)}>
+      <Form.Item label={Strings.assignUser} name={Constants.mechanic+Constants.id}>
+        <Select placeholder={`${Strings.selectRole} `} allowClear>
+          {siteUsers.map((user) => (
+            <Select.Option key={user.id} value={user.id}>
               {user.name}
             </Select.Option>
           ))}

--- a/src/pages/level/Levels.tsx
+++ b/src/pages/level/Levels.tsx
@@ -393,7 +393,7 @@ const Levels = ({ role }: Props) => {
             )}
             {isCloning && (
               <div className="absolute inset-0 flex justify-center items-center bg-gray-100 bg-opacity-50 z-50">
-                <Spin size="large" tip="Clonando nodos, por favor espere..." />
+                <Spin size="large" tip={Strings.cloningLevelsMessage} />
               </div>
             )}
           </>

--- a/src/pages/level/Levels.tsx
+++ b/src/pages/level/Levels.tsx
@@ -17,6 +17,7 @@ import { setSiteId } from "../../core/genericReducer";
 import { UnauthorizedRoute } from "../../utils/Routes";
 import { CreateNode } from "../../data/level/level.request";
 import { UserRoles } from "../../utils/Extensions";
+import Constants from "../../utils/Constants";
 
 const buildHierarchy = (data: Level[]) => {
   const map: { [key: string]: any } = {};
@@ -68,10 +69,12 @@ const Levels = ({ role }: Props) => {
   const [contextMenuVisible, setContextMenuVisible] = useState(false);
   const [contextMenuPos, setContextMenuPos] = useState({ x: 0, y: 0 });
 
+  const [isCloning, setIsCloning] = useState(false);
+
   const [drawerVisible, setDrawerVisible] = useState(false);
-  const [drawerType, setDrawerType] = useState<
-    "create" | "update" | "clone" | null
-  >(null);
+  const [drawerType, setDrawerType] = useState<"create" | "update" | null>(
+    null
+  );
   const [formData, setFormData] = useState<any>({});
 
   const [drawerPlacement, setDrawerPlacement] = useState<"right" | "bottom">(
@@ -85,8 +88,7 @@ const Levels = ({ role }: Props) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const siteName = location.state?.siteName || Strings.defaultSiteName;
-
-  const siteId = location.state.siteId;
+  const siteId = location.state?.siteId;
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -99,7 +101,6 @@ const Levels = ({ role }: Props) => {
     };
 
     document.addEventListener("click", handleClickOutside);
-
     return () => {
       document.removeEventListener("click", handleClickOutside);
     };
@@ -120,7 +121,6 @@ const Levels = ({ role }: Props) => {
 
     updateDrawerPlacement();
     window.addEventListener("resize", updateDrawerPlacement);
-
     return () => {
       window.removeEventListener("resize", updateDrawerPlacement);
     };
@@ -131,11 +131,9 @@ const Levels = ({ role }: Props) => {
       navigate(UnauthorizedRoute);
       return;
     }
-
     setLoading(true);
     try {
       const response = await getLevels(location.state.siteId).unwrap();
-
       setTreeData([
         {
           name: Strings.levelsOf.concat(siteName),
@@ -144,7 +142,6 @@ const Levels = ({ role }: Props) => {
         },
       ]);
       dispatch(setSiteId(location.state.siteId));
-
       if (containerRef.current) {
         const { offsetWidth, offsetHeight } = containerRef.current;
         setTranslate({ x: offsetWidth / 2, y: offsetHeight / 4 });
@@ -164,7 +161,6 @@ const Levels = ({ role }: Props) => {
   const handleCreateLevel = () => {
     closeAllDrawers();
     const supId = selectedNode?.data?.id;
-
     if (supId === "0") {
       createForm.setFieldsValue({ superiorId: null });
     } else if (!supId) {
@@ -172,7 +168,6 @@ const Levels = ({ role }: Props) => {
     } else {
       createForm.setFieldsValue({ superiorId: supId });
     }
-
     setDrawerType("create");
     setDrawerVisible(true);
     setContextMenuVisible(false);
@@ -182,7 +177,6 @@ const Levels = ({ role }: Props) => {
     closeAllDrawers();
     setDrawerType("update");
     updateForm.resetFields();
-
     if (selectedNode?.data) {
       updateForm.setFieldsValue(selectedNode.data);
     }
@@ -191,19 +185,72 @@ const Levels = ({ role }: Props) => {
     setContextMenuVisible(false);
   };
 
-  const handleCloneLevel = () => {
-    closeAllDrawers();
-    setDrawerType("clone");
-    createForm.resetFields();
-    console.log(selectedNode?.data);
-    if (selectedNode?.data) {
-      const { name, description, levelMachineId, ...filteredData } =
-        selectedNode.data;
-      createForm.setFieldsValue(filteredData);
+  const cloneSubtree = async (
+    node: any,
+    newSuperiorId: number | null = null,
+    isRoot: boolean = false
+  ): Promise<Level> => {
+    const allowedProperties = [
+      Constants.responsibleId,
+      Constants.siteId,
+      Constants.superiorId,
+      Constants.name,
+      Constants.description,
+      Constants.levelMachineId,
+      Constants.notify,
+    ];
+    const payload = allowedProperties.reduce((acc: any, key: string) => {
+      if (node[key] !== undefined) {
+        if ([Constants.responsibleId, Constants.siteId, Constants.superiorId, Constants.notify].includes(key)) {
+          acc[key] = node[key] !== null ? Number(node[key]) : node[key];
+        } else {
+          acc[key] = node[key];
+        }
+      }
+      return acc;
+    }, {});
+    if (!payload.siteId && location.state?.siteId) {
+      payload.siteId = Number(location.state.siteId);
+    }
+    payload.superiorId =
+      newSuperiorId !== null
+        ? newSuperiorId
+        : payload.superiorId !== undefined
+        ? Number(payload.superiorId)
+        : 0;
+    if (payload.levelMachineId && payload.levelMachineId.trim() !== Strings.empty) {
+      payload.levelMachineId = `${payload.levelMachineId}${Constants.cloneBridge}${node.id}`;
+    } else {
+      payload.levelMachineId = null;
     }
 
-    setDrawerVisible(true);
-    setContextMenuVisible(false);
+    payload.name = isRoot ? `${node.name} ${Strings.copy}` : node.name;
+    const newNodeData = await createLevel(payload).unwrap();
+    const parentId = Number(newNodeData.id);
+    if (isNaN(parentId)) {
+      throw new Error(Strings.errorGettingLevelId);
+    }
+    if (node.children && node.children.length > 0) {
+      for (const child of node.children) {
+        await cloneSubtree(child, parentId, false);
+      }
+    }
+    return newNodeData;
+  };
+
+  const handleCloneLevel = async () => {
+    if (!selectedNode?.data) return;
+    try {
+      setIsCloning(true);
+
+      await cloneSubtree(selectedNode.data, null, true);
+      await handleGetLevels();
+    } catch (error) {
+      console.error(Strings.errorCloningTheLevel, error);
+    } finally {
+      setIsCloning(false);
+      setContextMenuVisible(false);
+    }
   };
 
   const handleCloseDetails = () => {
@@ -220,19 +267,17 @@ const Levels = ({ role }: Props) => {
 
   const handleSubmit = async (values: any) => {
     try {
-      if (drawerType === "create" || drawerType === "clone") {
+      if (drawerType === "create") {
         const supIdNum = Number(values.superiorId);
-
         const newNode = new CreateNode(
           values.name?.trim(),
           values.description?.trim(),
           Number(values.responsibleId) || 0,
           Number(location.state.siteId),
           supIdNum,
-          values.levelMachineId?.trim() || "",
+          values.levelMachineId?.trim() || Strings.empty,
           values.notify ? 1 : 0
         );
-
         await createLevel(newNode).unwrap();
       } else if (drawerType === "update") {
         const { superiorId, ...updateValues } = values;
@@ -243,10 +288,8 @@ const Levels = ({ role }: Props) => {
             ? Number(values.responsibleId)
             : null,
         };
-
         await updateLevel(updatePayload).unwrap();
       }
-
       await handleGetLevels();
       handleDrawerClose();
     } catch (error) {
@@ -258,20 +301,15 @@ const Levels = ({ role }: Props) => {
 
   const renderCustomNodeElement = (rd3tProps: any) => {
     const { nodeDatum, toggleNode } = rd3tProps;
-
     const getCollapsedState = (nodeId: string): boolean => {
-      const storedState = localStorage.getItem(`node_${nodeId}_collapsed`);
+      const storedState = localStorage.getItem(`${Constants.nodeStartBridgeCollapsed}${nodeId}${Constants.nodeEndBridgeCollapserd}`);
       return storedState === "true";
     };
-
     const setCollapsedState = (nodeId: string, isCollapsed: boolean) => {
-      localStorage.setItem(`node_${nodeId}_collapsed`, isCollapsed.toString());
+      localStorage.setItem(`${Constants.nodeStartBridgeCollapsed}${nodeId}${Constants.nodeEndBridgeCollapserd}`, isCollapsed.toString());
     };
-
     const isCollapsed = getCollapsedState(nodeDatum.id);
-
     nodeDatum.__rd3t.collapsed = isCollapsed;
-
     const getFillColor = (status: string | undefined) => {
       switch (status) {
         case Strings.detailsOptionC:
@@ -283,9 +321,7 @@ const Levels = ({ role }: Props) => {
           return isLeafNode(nodeDatum) ? "#FFFF00" : "#145695";
       }
     };
-
     const fillColor = getFillColor(nodeDatum.status);
-
     const handleContextMenu = (e: React.MouseEvent<SVGGElement>) => {
       e.preventDefault();
       if (containerRef.current) {
@@ -296,7 +332,6 @@ const Levels = ({ role }: Props) => {
       setSelectedNode({ data: nodeDatum });
       setContextMenuVisible(true);
     };
-
     const handleShowDetails = (nodeId: string) => {
       if (nodeId !== "0") {
         closeAllDrawers();
@@ -305,19 +340,14 @@ const Levels = ({ role }: Props) => {
         setContextMenuVisible(false);
       }
     };
-
     const handleLeftClick = (e: React.MouseEvent<SVGGElement>) => {
       e.stopPropagation();
       setContextMenuVisible(false);
-
       const newCollapsedState = !nodeDatum.__rd3t.collapsed;
       setCollapsedState(nodeDatum.id, newCollapsedState);
-
       handleShowDetails(nodeDatum.id);
-
       toggleNode();
     };
-
     return (
       <g onClick={handleLeftClick} onContextMenu={handleContextMenu}>
         <circle r={15} fill={fillColor} stroke="none" strokeWidth={0} />
@@ -351,15 +381,22 @@ const Levels = ({ role }: Props) => {
             <Spin size="large" />
           </div>
         ) : (
-          treeData.length > 0 && (
-            <Tree
-              data={treeData}
-              orientation="horizontal"
-              translate={translate}
-              renderCustomNodeElement={renderCustomNodeElement}
-              collapsible={true}
-            />
-          )
+          <>
+            {treeData.length > 0 && (
+              <Tree
+                data={treeData}
+                orientation="horizontal"
+                translate={translate}
+                renderCustomNodeElement={renderCustomNodeElement}
+                collapsible={true}
+              />
+            )}
+            {isCloning && (
+              <div className="absolute inset-0 flex justify-center items-center bg-gray-100 bg-opacity-50 z-50">
+                <Spin size="large" tip="Clonando nodos, por favor espere..." />
+              </div>
+            )}
+          </>
         )}
       </div>
 
@@ -432,20 +469,14 @@ const Levels = ({ role }: Props) => {
 
       <Drawer
         title={
-          drawerType === Strings.drawerTypeCreate
+          drawerType === "create"
             ? Strings.levelsTreeOptionCreate.concat(
                 selectedNode?.data?.name
                   ? ` ${Strings.for} "${selectedNode.data.name}"`
                   : Strings.empty
               )
-            : drawerType === Strings.drawerTypeEdit
+            : drawerType === "update"
             ? Strings.levelsTreeOptionEdit.concat(
-                selectedNode?.data?.name
-                  ? ` "${selectedNode.data.name}" ${Strings.level}`
-                  : Strings.empty
-              )
-            : drawerType === Strings.drawerTypeClone
-            ? Strings.levelsTreeOptionClone.concat(
                 selectedNode?.data?.name
                   ? ` "${selectedNode.data.name}" ${Strings.level}`
                   : Strings.empty
@@ -469,23 +500,19 @@ const Levels = ({ role }: Props) => {
           }}
         >
           <div className="drawer-content">
-            {drawerType === "create" || drawerType === "clone" ? (
+            {drawerType === "create" ? (
               <RegisterLevelForm form={createForm} />
             ) : drawerType === "update" ? (
               <UpdateLevelForm form={updateForm} initialValues={formData} />
             ) : null}
-
             <div className="mt-4 flex justify-end">
               <Button
                 type="primary"
                 loading={isLoading}
                 onClick={() => {
-                  if (
-                    drawerType === Strings.drawerTypeCreate ||
-                    drawerType === Strings.drawerTypeClone
-                  ) {
+                  if (drawerType === "create") {
                     createForm.submit();
-                  } else if (drawerType === Strings.drawerTypeEdit) {
+                  } else if (drawerType === "update") {
                     updateForm.submit();
                   }
                 }}

--- a/src/services/apiSlice.ts
+++ b/src/services/apiSlice.ts
@@ -1,7 +1,7 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
 export const apiSlice = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3000", credentials: 'same-origin' }),
+  baseQuery: fetchBaseQuery({ baseUrl: import.meta.env.VITE_API_SERVICE, credentials: 'same-origin' }),
   tagTypes: ["User"],
   endpoints: (_) => ({}),
 });

--- a/src/services/apiSlice.ts
+++ b/src/services/apiSlice.ts
@@ -1,9 +1,7 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
 
-
-
 export const apiSlice = createApi({
-  baseQuery: fetchBaseQuery({ baseUrl: import.meta.env.VITE_API_SERVICE, credentials: 'same-origin' }),
+  baseQuery: fetchBaseQuery({ baseUrl: "http://localhost:3000", credentials: 'same-origin' }),
   tagTypes: ["User"],
-  endpoints: (_) => ({}),
+  endpoints: (_) => ({}),
 });

--- a/src/services/levelService.ts
+++ b/src/services/levelService.ts
@@ -8,13 +8,14 @@ export const levelService = apiSlice.injectEndpoints({
       query: (siteId) => `/level/site/${siteId}`,
       transformResponse: (response: { data: Level[] }) => response.data,
     }),
-    createLevel: builder.mutation<void, CreateLevel>({
+    createLevel: builder.mutation<Level, CreateLevel>({
       query: (level) => ({
         url: "/level/create",
         method: "POST",
         body: { ...level },
       }),
-    }),
+      transformResponse: (response: { data: Level }) => response.data,
+    }),  
     getlevel: builder.mutation<Level, string>({
       query: (id) => `/level/${id}`,
       transformResponse: (response: { data: Level }) => response.data,

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -19,6 +19,19 @@ const esOption = "Español"
 const externalProviderRouteVal = "/external/"
 const externalProviderConstant = "external"
 
+// Level Clonation
+const responsibleId = "responsibleId";
+const siteId = "siteId";
+const superiorId = "superiorId";
+const name = "name";
+const description = "description";
+const levelMachineId = "levelMachineId";
+const notify = "notify";
+
+const cloneBridge = "_clone_";
+const nodeStartBridgeCollapsed = "node_";
+const nodeEndBridgeCollapserd = "_collapsed";
+
 
 export default {
   PAGE_SIZE,
@@ -37,5 +50,15 @@ export default {
   esOption,
   enOption,
   externalProviderRouteVal,
-  externalProviderConstant
+  externalProviderConstant,
+  responsibleId,
+  siteId,
+  superiorId,
+  name,
+  description,
+  levelMachineId,
+  notify,
+  cloneBridge,
+  nodeStartBridgeCollapsed,
+  nodeEndBridgeCollapserd
 };

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -583,6 +583,11 @@ static false = "false"
  static commentsTag = "commentsTag"
  static noCommentsTag = "noCommentsTag"
  static associatedTags = "associatedTags"
+
+ static copy = "copy";
+ static errorGettingLevelId = "errorGettingLevelId";
+ static errorCloningTheLevel = "errorCloningTheLevel";
+
 }
 
 const Strings = new Proxy(StringsBase, {

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -587,6 +587,8 @@ static false = "false"
  static copy = "copy";
  static errorGettingLevelId = "errorGettingLevelId";
  static errorCloningTheLevel = "errorCloningTheLevel";
+ static cloningLevelsMessage = "cloningLevelsMessage";
+
 
 }
 


### PR DESCRIPTION
### Feature / Bug Description
Clone the child levels in the levels tree. Previously, only the node was cloned without its child nodes.

### Solution
Use a recursive function to surf on the tree and clone each node.

### Notes


### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-75)

### Screenshots / Screencasts
![image](https://github.com/user-attachments/assets/1400d3a9-da21-448b-b97e-a3a5c3d03f45)

