### PR TITLE
[v1.13] KAN - 101/Cilt bugs and refactors second part

### DIFF
--- a/src/config/i18n.ts
+++ b/src/config/i18n.ts
@@ -822,14 +822,16 @@ const resources = {
       oplDescription:
         "This page contains information about One Point Lessons (OPL).",
       ciltTypesSB: "CILT Types",
+      ciltTypesOf: "CILT Types of",
       ciltTypesDescription:
         "This page contains information about different types of CILT.",
       ciltFrecuenciesSB: "CILT Frequencies",
+      ciltFrecuenciesOf: "CILT Frequencies of",
       ciltFrecuenciesDescription:
         "This page contains information about CILT frequencies.",
 
       //CILT TYPES IN ENGLISH
-      searchbyname: "Search by name",
+      searchByName: "Search by name",
       addNewCiltType: "Add new type of CILT",
       errorLoadingNewTypesCilt: "Error loading CILT types",
       typeCiltUpdated: "Type Cilt Updated",
@@ -840,6 +842,8 @@ const resources = {
       obligatoryName: "The name is obligatory",
       editCiltType: "Edit Cilt Type",
       addCiltType: "Add Cilt Type",
+      errorNoSiteId: "A site Id is obligatory",
+      clearFilters: "Clear filters",
 
       //CILT FREQUENCIES IN ENGLISH
       frequencyCode: "Frequency Code",
@@ -2081,39 +2085,41 @@ const resources = {
       oplDescription:
         "Esta página contiene información sobre One Point Lessons (OPL).",
       ciltTypesSB: "Tipos de CILT",
+      ciltTypesOf: "Tipos de CILT de",
       ciltTypesDescription:
         "Esta página contiene información sobre diferentes tipos de CILT.",
       ciltFrecuenciesSB: "Frecuencias de CILT",
+      ciltFrecuenciesOf: "Frecuencias de CILT de",
       ciltFrecuenciesDescription:
         "Esta página contiene información sobre frecuencias de CILT.",
 
-      //CILT TYPES IN ENGLISH
-      searchbyname: "Search by name",
-      addNewCiltType: "Add new type of CILT",
-      errorLoadingNewTypesCilt: "Error loading CILT types",
-      typeCiltUpdated: "Type Cilt Updated",
-      errorUpdatingCiltType: "Error updating CILT type",
-      ciltTypeAdded: "Cilt type added",
-      errorAddingCiltType: "Error adding CILT type",
-      noCiltTypes: "There are no CILT types to display.",
-      obligatoryName: "The name is obligatory",
-      editCiltType: "Edit Cilt Type",
-      addCiltType: "Add Cilt Type",
-
-      //CILT FREQUENCIES IN ENGLISH
-      frequencyCode: "Frequency Code",
-      addNewCiltFrequency: "Add New Cilt Frequency",
-      editCiltFrequency: "Edit Cilt Frequency",
-      addCiltFrequency: "Add Frequency",
-      ciltFrequencyAdded: "Frequency added successfully",
-      ciltFrequencyUpdated: "Frequency updated successfully",
-      errorAddingCiltFrequency: "Error adding frequency",
-      errorUpdatingCiltFrequency: "Error updating frequency",
-      errorLoadingCiltFrequencies: "Error loading frequencies",
-      noCiltFrequencies: "No frequencies available",
-      obligatoryCode: "Frequency code is required",
-      obligatoryDescription: "Description is required",
-      searchbyDescriptionOrCode: "Search by code or description",
+  
+        searchByName: "Buscar por nombre",
+        addNewCiltType: "Agregar nuevo tipo de CILT",
+        errorLoadingNewTypesCilt: "Error al cargar los tipos de CILT",
+        typeCiltUpdated: "Tipo de CILT actualizado",
+        errorUpdatingCiltType: "Error al actualizar el tipo de CILT",
+        ciltTypeAdded: "Tipo de CILT agregado",
+        errorAddingCiltType: "Error al agregar el tipo de CILT",
+        noCiltTypes: "No hay tipos de CILT para mostrar.",
+        obligatoryName: "El nombre es obligatorio",
+        editCiltType: "Editar tipo de CILT",
+        addCiltType: "Agregar tipo de CILT",
+        
+        frequencyCode: "Código de frecuencia",
+        addNewCiltFrequency: "Agregar nueva frecuencia de CILT",
+        editCiltFrequency: "Editar frecuencia de CILT",
+        addCiltFrequency: "Agregar frecuencia",
+        ciltFrequencyAdded: "Frecuencia agregada exitosamente",
+        ciltFrequencyUpdated: "Frecuencia actualizada exitosamente",
+        errorAddingCiltFrequency: "Error al agregar la frecuencia",
+        errorUpdatingCiltFrequency: "Error al actualizar la frecuencia",
+        errorLoadingCiltFrequencies: "Error al cargar las frecuencias",
+        noCiltFrequencies: "No hay frecuencias disponibles",
+        obligatoryCode: "El código de frecuencia es obligatorio",
+        obligatoryDescription: "La descripción es obligatoria",
+        searchbyDescriptionOrCode: "Buscar por código o descripción",
+        
 
       // CILT Master strings
       ciltMstrPageTitle: "Procedimientos CILT",
@@ -2510,8 +2516,15 @@ const resources = {
       cilt: "CILT",
       selectedUsersList: "Usuarios seleccionados:",
       ciltMstrLastUpdated: "Última actualización:",
+
+      
       lastLoginWeb: "Ultimo login web",
-      lastLoginApp: "Ultimo login app"
+      lastLoginApp: "Ultimo login app",
+      
+      errorNoSiteId: "El id del site es obligatorio",
+      clearFilters: "Limpiar filtros",
+
+      
     },
   },
 };

--- a/src/data/cilt/ciltTypes/ciltTypes.ts
+++ b/src/data/cilt/ciltTypes/ciltTypes.ts
@@ -1,41 +1,48 @@
 export interface CiltType {
-    id: number;
-    siteId: number | null;
-    name: string | null;
-    status: string | null;
+  id: number;
+  siteId: number | null;
+  name: string | null;
+  status: string | null;
+  color: string | null; 
+}
+
+export class CreateCiltTypeDTO {
+  siteId?: number;
+  name?: string;
+  status?: string;
+  color?: string;
+
+  constructor(
+    siteId?: number,
+    name?: string,
+    status?: string,
+    color?: string
+  ) {
+    this.siteId = siteId;
+    this.name = name;
+    this.status = status;
+    this.color = color; 
   }
-  
-  export class CreateCiltTypeDTO {
-    siteId?: number;
-    name?: string;
-    status?: string;
-  
-    constructor(
-      siteId?: number,
-      name?: string,
-      status?: string
-    ) {
-      this.siteId = siteId;
-      this.name = name;
-      this.status = status;
-    }
+}
+
+export class UpdateCiltTypeDTO {
+  id: number;
+  siteId?: number;
+  name?: string;
+  status?: string;
+  color?: string;
+
+  constructor(
+    id: number,
+    siteId?: number,
+    name?: string,
+    status?: string,
+    color?: string
+  ) {
+    this.id = id;
+    this.siteId = siteId;
+    this.name = name;
+    this.status = status;
+    this.color = color;
   }
-  
-  export class UpdateCiltTypeDTO {
-    id: number;
-    siteId?: number;
-    name?: string;
-    status?: string;
-  
-    constructor(
-      id: number,
-      siteId?: number,
-      name?: string,
-      status?: string
-    ) {
-      this.id = id;
-      this.siteId = siteId;
-      this.name = name;
-      this.status = status;
-    }
-  }
+}

--- a/src/pages/ciltFrecuencies/CiltFrecuenciesPage.tsx
+++ b/src/pages/ciltFrecuencies/CiltFrecuenciesPage.tsx
@@ -2,11 +2,17 @@ import React from "react";
 import Strings from "../../utils/localizations/Strings";
 import MainContainer from "../../pagesRedesign/layout/MainContainer";
 import CiltFrecuencies from "./components/CiltFrecuencies";
+import { useLocation  } from "react-router-dom";
 
 const CiltFrecuenciesPage = (): React.ReactElement => {
+
+    const location = useLocation();
+     const siteName = location?.state?.siteName || Strings.empty;
+
   return (
     <MainContainer 
-      title={Strings.ciltFrecuenciesSB}
+      title={Strings.ciltFrecuenciesOf}
+      description={siteName}
       content={<CiltFrecuencies />}
     />
   );

--- a/src/pages/ciltFrecuencies/components/CiltFrecuencies.tsx
+++ b/src/pages/ciltFrecuencies/components/CiltFrecuencies.tsx
@@ -21,6 +21,11 @@ import {
 
 import { CiltFrequency } from "../../../data/cilt/ciltFrequencies/ciltFrequencies";
 
+import AnatomyButton from "../../../components/AnatomyButton";
+import { FilterOutlined } from "@ant-design/icons";
+import { Checkbox, Popover } from "antd";
+
+
 const { Text } = Typography;
 
 const CiltFrequencies = (): React.ReactElement => {
@@ -42,6 +47,8 @@ const CiltFrequencies = (): React.ReactElement => {
   const [createCiltFrequency] = useCreateCiltFrequencyMutation();
   const [updateCiltFrequency] = useUpdateCiltFrequencyMutation();
 
+
+
   useEffect(() => {
     fetchCiltFrequencies();
   }, []);
@@ -53,11 +60,13 @@ const CiltFrequencies = (): React.ReactElement => {
   const fetchCiltFrequencies = async () => {
     try {
       const data = await getCiltFrequenciesAll().unwrap();
-      setCiltFrequencies(data);
+      const filteredBySite = data.filter(item => item.siteId === Number(siteId));
+      setCiltFrequencies(filteredBySite);
     } catch (error) {
       message.error(Strings.errorLoadingCiltFrequencies);
     }
   };
+
 
   const filterData = () => {
     let filtered = ciltFrequencies;
@@ -102,11 +111,18 @@ const CiltFrequencies = (): React.ReactElement => {
   };
 
   const handleModalOk = () => {
+
+    if (!siteId) {
+      message.error(Strings.errorNoSiteId);
+      return;
+    }
+
+
     form.validateFields().then((values) => {
       const payload = {
         ...values,
         siteId: Number(siteId),
-        status: isEditMode ? (values.status ? "A" : "I") : "A", 
+        status: isEditMode ? (values.status ? "A" : "I") : "A",
       };
 
       if (isEditMode && currentRecord) {
@@ -145,21 +161,41 @@ const CiltFrequencies = (): React.ReactElement => {
             onChange={(e) => setSearchText(e.target.value)}
             style={{ width: 300 }}
           />
-          <Switch
-            checked={statusFilter === true}
-            onChange={(checked) => setStatusFilter(checked ? true : false)}
-            checkedChildren={Strings.active}
-            unCheckedChildren={Strings.inactive}
-          />
+
+          <Popover
+            trigger="click"
+            content={
+              <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+                <Checkbox
+                  checked={statusFilter === true}
+                  onChange={(e) => setStatusFilter(e.target.checked ? true : null)}
+                >
+                  {Strings.active}
+                </Checkbox>
+                <Checkbox
+                  checked={statusFilter === false}
+                  onChange={(e) => setStatusFilter(e.target.checked ? false : null)}
+                >
+                  {Strings.inactive}
+                </Checkbox>
+                <Button size="small" type="link" onClick={() => setStatusFilter(null)}>
+                  {Strings.clearFilters}
+                </Button>
+              </div>
+            }
+          >
+            <Button icon={<FilterOutlined />}>{Strings.filter}</Button>
+          </Popover>
+
         </div>
 
-        <button
-          className="ant-btn ant-btn-primary"
+        <AnatomyButton
+          title={Strings.create}
           onClick={openAddModal}
-          style={{ cursor: 'pointer', borderRadius: '2px' }}
-        >
-          {Strings.addNewCiltFrequency}
-        </button>
+          type="default"
+          size="middle"
+        />
+
       </div>
 
       <List
@@ -173,29 +209,18 @@ const CiltFrequencies = (): React.ReactElement => {
         renderItem={(item: CiltFrequency) => (
           <List.Item>
             <Card
-              headStyle={{ backgroundColor: '#1890ff', color: 'white', fontWeight: 'bold' }}
-              title={item.frecuencyCode}
-              style={{ 
-                height: '100%',
-                boxShadow: '0 1px 2px rgba(0,0,0,0.15)',
-                border: '1px solid #e8e8e8',
-                transition: 'all 0.3s ease'
-              }}
-              onMouseEnter={(e) => {
-                const target = e.currentTarget;
-                target.style.boxShadow = '0 3px 6px rgba(0,0,0,0.2)';
-                target.style.transform = 'translateY(-2px)';
-              }}
-              onMouseLeave={(e) => {
-                const target = e.currentTarget;
-                target.style.boxShadow = '0 1px 2px rgba(0,0,0,0.15)';
-                target.style.transform = 'translateY(0)';
-              }}
+              hoverable
+              className="rounded-xl shadow-md"
+              title={
+                <Typography.Title level={5} style={{ marginBottom: 0 }}>
+                  {item.frecuencyCode}
+                </Typography.Title>
+              }
             >
-              <Space direction="vertical" style={{ width: '100%' }}>
+              <Space direction="vertical" style={{ width: '100%' }} className="bg-gray-100 rounded-md p-3">
                 <Text strong>{Strings.description}:</Text>
                 <Text>{item.description}</Text>
-                
+
                 <Text strong style={{ marginTop: '8px' }}>
                   {Strings.status}: {' '}
                   {item.status === 'A' ? (

--- a/src/pages/ciltTypes/CiltTypesPage.tsx
+++ b/src/pages/ciltTypes/CiltTypesPage.tsx
@@ -2,11 +2,18 @@ import React from "react";
 import Strings from "../../utils/localizations/Strings";
 import MainContainer from "../../pagesRedesign/layout/MainContainer";
 import CiltTypes from "./components/CiltTypes";
+import { useLocation  } from "react-router-dom";
+
 
 const CiltTypesPage = (): React.ReactElement => {
+
+  const location = useLocation();
+   const siteName = location?.state?.siteName || Strings.empty;
+
   return (
     <MainContainer 
-      title={Strings.ciltTypesSB}
+      title={Strings.ciltTypesOf}
+      description={siteName}
       content={<CiltTypes />}
     />
   );

--- a/src/pages/ciltTypes/components/CiltTypes.tsx
+++ b/src/pages/ciltTypes/components/CiltTypes.tsx
@@ -120,14 +120,13 @@ const CiltTypes = (): React.ReactElement => {
     }
 
     form.validateFields().then((values) => {
-      // Quitar '#' antes de enviar
       if (values.color && values.color.startsWith('#')) {
         values.color = values.color.slice(1);
       }
 
       const payload = {
         ...values,
-        status: values.status ? 'A' : 'I',
+        status: values.status ? Strings.activeValue : Strings.inactiveValue,
         siteId: Number(siteId),
       };
 

--- a/src/services/cilt/ciltFrequenciesService.ts
+++ b/src/services/cilt/ciltFrequenciesService.ts
@@ -7,9 +7,14 @@ import {
 
 export const ciltFrequenciesService = apiSlice.injectEndpoints({
   endpoints: (builder) => ({
-    // GET /cilt-frequencies/all
+    // GET /cilt-frequencies/alla
     getCiltFrequenciesAll: builder.mutation<CiltFrequency[], void>({
       query: () => `/cilt-frequencies/all`,
+      transformResponse: (response: { data: CiltFrequency[] }) => response.data,
+    }),
+
+    getCiltTypesBySite: builder.mutation<CiltFrequency[], string>({
+      query: (siteId) => `/cilt-types/site/${siteId}`,
       transformResponse: (response: { data: CiltFrequency[] }) => response.data,
     }),
 
@@ -44,6 +49,7 @@ export const ciltFrequenciesService = apiSlice.injectEndpoints({
 
 export const {
   useGetCiltFrequenciesAllMutation,
+   useGetCiltTypesBySiteMutation,
   useGetCiltFrequencyByIdMutation,
   useCreateCiltFrequencyMutation,
   useUpdateCiltFrequencyMutation,

--- a/src/utils/localizations/Strings.ts
+++ b/src/utils/localizations/Strings.ts
@@ -791,12 +791,14 @@ class StringsBase {
   static oplSB = "oplSB";
   static oplDescription = "oplDescription";
   static ciltTypesSB = "ciltTypesSB";
+  static ciltTypesOf = "ciltTypesOf";
   static ciltTypesDescription = "ciltTypesDescription";
   static ciltFrecuenciesSB = "ciltFrecuenciesSB";
+  static ciltFrecuenciesOf = "ciltFrecuenciesOf";
   static ciltFrecuenciesDescription = "ciltFrecuenciesDescription";
 
   //Cilt Types
-  static searchbyname = "searchbyname";
+  static searchByName = "searchByName";
   static addNewCiltType = "addNewCiltType";
   static errorLoadingNewTypesCilt = "errorLoadingNewTypesCilt";
   static typeCiltUpdated = "typeCiltUpdated";
@@ -808,6 +810,9 @@ class StringsBase {
   static add = "add";
   static editCiltType = "editCiltType";
   static addCiltType = "addCiltType";
+  static errorNoSiteId = "errorNoSiteId";
+  static clearFilters = "clearFilters";
+
 
   //Cilt Frequency
   static frequencyCode = "frequencyCode";


### PR DESCRIPTION
### Feature / Bug Description
This PR contains the second part of the corrections and refactors of the cilt module.

### Solution
I redesigned the sections Cilt Types and Cilt Frequencies to match the design of the Users section.
I improved the status filter to be more user-friendly.
Now, the SiteId filter works correctly, and users can only see the Cilt Frequencies and Cilt Types associated with their enterprise.

### Notes

### Tickets
[TICKET](https://one-sm.atlassian.net/browse/KAN-101)

### Screenshots / Screencasts